### PR TITLE
Frozen hypergraphs

### DIFF
--- a/xgi/classes/__init__.py
+++ b/xgi/classes/__init__.py
@@ -1,4 +1,5 @@
 from .hypergraph import Hypergraph
+from .frozen import FrozenHypergraph
 from .function import *
 from xgi.classes import hypergraphviews
 from xgi.classes import reportviews

--- a/xgi/classes/frozen.py
+++ b/xgi/classes/frozen.py
@@ -1,0 +1,46 @@
+"""Class for a hypergraph that can be frozen."""
+
+from functools import lru_cache
+
+from xgi.classes import Hypergraph
+
+__all__ = ["FrozenHypergraph"]
+
+
+def cache_when_frozen(method):
+
+    @lru_cache
+    def cached(self, *args, **kwargs):
+        return method(self, *args, **kwargs)
+
+    def wrapper(self, *args, **kwargs):
+        if self.frozen:
+            return cached(self, *args, **kwargs)
+        else:
+            return method(self, *args, **kwargs)
+
+    return wrapper
+
+
+class FrozenHypergraph(Hypergraph):
+    """Hypergraph that can be frozen by calling freeze().
+
+    A frozen hypergraph caches the results of many of its methods and will therefore be
+    much faster (but use more memory) than a standard hypergraph.
+
+    """
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._frozen = False
+
+    @property
+    def frozen(self):
+        return self._frozen
+
+    def freeze(self):
+        self._frozen = True
+
+    @cache_when_frozen
+    def is_uniform(self):
+        return super().is_uniform()


### PR DESCRIPTION
Welp, here it is. The results speak for themselves:

```python

>>> import xgi
>>> H = xgi.FrozenHypergraph([[0, 1, 2], [1, 2, 3], [2, 3, 4], [4]])
>>> H.is_uniform()
2

>>> %timeit H.is_uniform()
2.78 µs ± 48.8 ns per loop (mean ± std. dev. of 7 runs, 100000 loops each)

>>> H.freeze()

>>> %timeit H.is_uniform()
296 ns ± 1.68 ns per loop (mean ± std. dev. of 7 runs, 1000000 loops each)
```

This particular method is already 10x faster on this particular (small!) hypergraph.

A couple of notes:
1. I think the implementation is an abomination and I'm ashamed of myself for pushing this publicly.
2. Ok not so much, but honestly the thing is not pretty and I can already tell it'll be a mess to debug.
3. I've only implemented one method for now to get yall's opinions before merging.

PLEASE DO NOT MERGE THIS YET. Feel free to review and leave comments.

Closes #31.