### PR TITLE
Fix IPython error

### DIFF
--- a/requirements/tutorial.txt
+++ b/requirements/tutorial.txt
@@ -1,3 +1,4 @@
 jupyter>=1.0
 matplotlib>=3.3
 seaborn>=0.10
+ipython<=8.13

--- a/requirements/tutorial.txt
+++ b/requirements/tutorial.txt
@@ -1,4 +1,4 @@
 jupyter>=1.0
 matplotlib>=3.3
 seaborn>=0.10
-ipython<=8.13
+ipython<=8.12.0


### PR DESCRIPTION
Fix Tutorials Github Actions. IPython 8.13 removes support for Python 3.9