### PR TITLE
Remove hardcoded alpha from hyperedge drawing

### DIFF
--- a/xgi/drawing/draw.py
+++ b/xgi/drawing/draw.py
@@ -466,7 +466,6 @@ def draw_hyperedges(
             obj = plt.Polygon(
                 sorted_coordinates,
                 facecolor=edge_fc[id],
-                alpha=0.4,
                 zorder=max_order - d,
             )
             ax.add_patch(obj)


### PR DESCRIPTION
The transparency of hyperedges is currently hardcoded to 0.4.

The following code:
```python3
import xgi
import matplotlib.pyplot as plt
H = xgi.Hypergraph([[1,2,3], [2,3,4]])
xgi.draw(H, edge_fc=[[0,0,1,1], [0,0,1,0.1]])
plt.show()
```

Before this PR:

<img src="https://user-images.githubusercontent.com/1096704/235844789-422670c2-3fd6-4455-a57b-27b4504fd58d.png" width="350" />


After this PR:

<img src="https://user-images.githubusercontent.com/1096704/235844762-e40a9b99-ecaa-408e-a25a-f853f3c68453.png" width="350" />

Cc. @iaciac 