### PR TITLE
Update sphinx

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,14 +16,13 @@ Sign up for our [mailing list](http://eepurl.com/igE6ez) and follow XGI on [Twit
 ## Table of Contents:
   - [Installation](#installation)
   - [Getting Started](#getting-started)
-  - [Documentation](#documentation)
+  - [How to Contribute](#contributing)
   - [Corresponding Data](#corresponding-data)
-  - [Contributing](#contributing)
   - [How to Cite](#how-to-cite)
-  - [Code of Conduct](#code-of-conduct)
   - [License](#license)
   - [Funding](#funding)
   - [Other Resources](#other-resources)
+
 
 ## Installation
 XGI runs on Python 3.8 or higher.
@@ -45,35 +44,31 @@ pip install -e .["all"]
 pip install -e .\[all\]
 ````
 
-## Getting Started
 
+## Getting Started
 To get started, take a look at the [tutorials](/tutorials/) illustrating the library's basic functionality.
 
-## Documentation
-
-For more documentation, see our [Read The Docs](https://xgi.readthedocs.io/en/latest/) page.
 
 ## Corresponding Data
-
 A number of higher-order datasets are available in the [XGI-DATA repository](https://gitlab.com/complexgroupinteractions/xgi-data) and can be easily accessed with the `load_xgi_data()` function.
 
-## Contributing
+
+## How to Contribute
 If you want to contribute to this project, please make sure to read the
-[code of conduct](CODE_OF_CONDUCT.md)
-and the [contributing guidelines](CONTRIBUTING.md).
+[contributing guidelines](CONTRIBUTING.md). We expect respectful and kind interactions by all contributors and users as laid out in our [code of conduct](CODE_OF_CONDUCT.md).
 
-The best way to contribute to XGI is by submitting a bug or request a new feature by
-opening a [new issue](https://github.com/xgi-org/xgi/issues/new).
+The XGI community always welcomes contributions, no matter how small. We're happy to help troubleshoot XGI issues you run into, assist you if you would like to add functionality or fixes to the codebase, or answer any questions you may have.
 
-To get more actively involved, you are invited to browse the [issues page](../../issues) and choose one that you can
-work on.  The core developers will be happy to help you understand the codebase and any
-other doubts you may have while working on your contribution.
+Some concrete ways that you can get involved:
 
-If you are interested in the daily goings-on of XGI, you are invited to join our [Zulip
-channel](https://xgi.zulipchat.com/join/7agfwo7dh7jo56ppnk5kc23r/).
+* **Get XGI updates** by following the XGI [Twitter](https://twitter.com/xginets) account, signing up for our [mailing list](http://eepurl.com/igE6ez), or starring this repository.
+* **Spread the word** when you use XGI by sharing with your colleagues and friends.
+* **Request a new feature or report a bug** by raising a [new issue](https://github.com/xgi-org/xgi/issues/new).
+* **Create a Pull Request (PR)** to address an [open issue](../../issues) or add a feature.
+* **Join our [Zulip channel](https://xgi.zulipchat.com/join/7agfwo7dh7jo56ppnk5kc23r/)** to be a part of the daily goings-on of XGI.
+
 
 ## How to Cite
-
 We acknowledge the importance of good software to support research, and we note
 that research becomes more valuable when it is communicated effectively. To
 demonstrate the value of XGI, we ask that you cite XGI in your work.
@@ -82,28 +77,19 @@ Currently, the best way to cite XGI is to go to our
 click the "cite this repository" button on the right sidebar. This will generate
 a citation in your preferred format, and will also integrate well with citation managers.
 
-## Code of Conduct
-
-Our full code of conduct, and how we enforce it, can be read in [our repository](CODE_OF_CONDUCT.md).
 
 ## License
 Released under the 3-Clause BSD license (see [`LICENSE.md`](LICENSE.md))
 
 Copyright (C) 2021-2023 XGI Developers
 
-Nicholas Landry <nicholas.landry@uvm.edu>
-
-Leo Torres <leo@leotrs.com>
-
-Iacopo Iacopini <iacopiniiacopo@gmail.com>
-
-Maxime Lucas <maxime.lucas@centai.eu>
-
-Giovanni Petri <giovanni.petri@centai.eu>
-
-Alice Patania <apatania@uvm.edu>
-
-Alice Schwarze <alice.c.schwarze@dartmouth.edu>
+* Nicholas Landry <nicholas.landry@uvm.edu>
+* Leo Torres <leo@leotrs.com>
+* Iacopo Iacopini <iacopiniiacopo@gmail.com>
+* Maxime Lucas <maxime.lucas@centai.eu>
+* Giovanni Petri <giovanni.petri@centai.eu>
+* Alice Patania <apatania@uvm.edu>
+* Alice Schwarze <alice.c.schwarze@dartmouth.edu>
 
 The XGI library has copied or modified code from the HyperNetX and NetworkX libraries, the licenses of which can be found in our [license file](LICENSE.md)
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -150,7 +150,7 @@ todo_include_todos = True
 
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
-html_theme = "pydata_sphinx_theme"
+html_theme = "sphinx_rtd_theme"
 
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -43,7 +43,7 @@ copybutton_prompt_is_regexp = True
 #
 # This is also used if you do content translation via gettext catalogs.
 # Usually you set "language" from the command line for these cases.
-language = None
+language = "en"
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
@@ -105,7 +105,7 @@ root_doc = "index"
 #
 # This is also used if you do content translation via gettext catalogs.
 # Usually you set "language" from the command line for these cases.
-language = None
+language = "en"
 
 # There are two options for replacing |today|: either, you set today to some
 # non-false value, then it is used:
@@ -150,9 +150,7 @@ todo_include_todos = True
 
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
-# html_theme = 'nature'
-html_theme = "sphinx_rtd_theme"
-# html_theme = 'pyramid'
+html_theme = "pydata_sphinx_theme"
 
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -64,8 +64,8 @@ designed and developed by network scientists with the needs of network scientist
 mind.
 
 - Repository: https://github.com/xgi-org/xgi
-- PyPI: https://pypi.org/project/xgi/
-- Documentation: https://xgi.readthedocs.io/
+- PyPI: `latest release <https://pypi.org/project/xgi/>`_
+- Twitter: `@xginets <https://twitter.com/xginets>`_
 
 Sign up for our `mailing list <http://eepurl.com/igE6ez>`_ and follow XGI on `Twitter <https://twitter.com/xginets>`_ or `Mastodon <https://mathstodon.xyz/@xginets>`_!
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -93,11 +93,43 @@ If that command does not work, you may try the following instead
 
 XGI was developed and tested for Python 3.8-3.11 on Mac OS, Windows, and Ubuntu.
 
+
 Corresponding Data
 ==================
 
 A number of higher-order datasets are available in the `XGI-DATA repository <https://gitlab.com/complexgroupinteractions/xgi-data>`_ and can be easily accessed with the ``load_xgi_data()`` function.
 
+
+Contributing
+============
+
+If you want to contribute to this project, please make sure to read the
+`contributing guidelines <CONTRIBUTING.md>`_.
+We expect respectful and kind interactions by all contributors and users
+as laid out in our `code of conduct <CODE_OF_CONDUCT.md>`_.
+
+The XGI community always welcomes contributions, no matter how small.
+We're happy to help troubleshoot XGI issues you run into,
+assist you if you would like to add functionality or fixes to the codebase,
+or answer any questions you may have.
+
+Some concrete ways that you can get involved:
+
+* **Get XGI updates** by following the XGI `Twitter <https://twitter.com/xginets>`_ account, signing up for our `mailing list <http://eepurl.com/igE6ez>`_, or starring this repository.
+* **Spread the word** when you use XGI by sharing with your colleagues and friends.
+* **Request a new feature or report a bug** by raising a `new issue <https://github.com/xgi-org/xgi/issues/new>`_.
+* **Create a Pull Request (PR)** to address an `open issue <../../issues>`_ or add a feature.
+* **Join our Zulip channel** to be a part of the `daily goings-on of XGI <https://xgi.zulipchat.com/join/7agfwo7dh7jo56ppnk5kc23r/>`_.
+
+How to Cite
+===========
+We acknowledge the importance of good software to support research, and we note
+that research becomes more valuable when it is communicated effectively. To
+demonstrate the value of XGI, we ask that you cite XGI in your work.
+Currently, the best way to cite XGI is to go to our
+`repository page <https://github.com/xgi-org/xgi>`_ and
+click the "cite this repository" button on the right sidebar. This will generate
+a citation in your preferred format, and will also integrate well with citation managers.
 
 Academic References
 ===================
@@ -119,27 +151,6 @@ Academic References
   Rosvall, and Ingo Scholtes.
 
 
-Contributing
-============
-
-If you want to contribute to this project, please make sure to read the
-`code of conduct
-<https://github.com/xgi-org/xgi/blob/main/CODE_OF_CONDUCT.md>`_
-and the `contributing guidelines
-<https://github.com/xgi-org/xgi/blob/main/CONTRIBUTING.md>`_.
-
-The best way to contribute to XGI is by submitting a bug or request a new feature by
-opening a `new issue <https://github.com/xgi-org/xgi/issues/new>`_.
-
-To get more actively involved, you are invited to browse the `issues page
-<https://github.com/xgi-org/xgi/issues>`_ and choose one that you can
-work on.  The core developers will be happy to help you understand the codebase and any
-other doubts you may have while working on your contribution.
-
-If you are interested in the daily goings-on of XGI, you are invited to join our `Zulip
-channel <https://xgi.zulipchat.com/join/7agfwo7dh7jo56ppnk5kc23r/>`_.
-
-
 Contributors
 ============
 
@@ -159,6 +170,9 @@ Other contributors:
 * Tim LaRock
 * Sabina Adhikari
 * Marco Nurisso
+* Alexis Arnaudon
+* Thomas Robiglio
+* Gonzalo Contreras Aso
 
 Funding
 =======

--- a/long_description.rst
+++ b/long_description.rst
@@ -67,10 +67,6 @@ Currently, the best way to cite XGI is to go to our
 click the "cite this repository" button on the right sidebar. This will generate
 a citation in your preferred format, and will also integrate well with citation managers.
 
-Code of Conduct
----------------
-Our full code of conduct, and how we enforce it, can be read in `our repository <https://github.com/xgi-org/xgi/tree/main/CODE_OF_CONDUCT.md>`_.
-
 License
 -------
 Released under the 3-Clause BSD license (see the `license file <https://github.com/xgi-org/xgi/tree/main/license.md>`_)

--- a/long_description.rst
+++ b/long_description.rst
@@ -4,8 +4,12 @@ XGI
 .. image:: https://github.com/xgi-org/xgi/raw/main/logo/logo.svg
   :width: 200
 
-CompleX Group Interactions (XGI) is a Python package for the representation, manipulation,
-and study of the structure, dynamics, and functions of complex systems with group (higher-order) interactions.
+XGI is a Python package for higher-order networks.
+
+Comple**X** **G**roup **Interactions** (XGI) provides an ecosystem for the
+representation, manipulation, and study of the
+structure, dynamics, and functions of
+complex systems with group (higher-order) interactions.
 
 Installation
 ------------
@@ -29,12 +33,29 @@ Getting Started
 To get started, take a look at the `tutorials <https://github.com/xgi-org/xgi/tree/main/tutorials>`_
 illustrating the library's basic functionality.
 
+Corresponding Data
+------------------
+A number of higher-order datasets are available in the `XGI-DATA repository <https://gitlab.com/complexgroupinteractions/xgi-data>`_ and can be easily accessed with the ``load_xgi_data()`` function.
+
 Contributing
 ------------
-Contributions are always welcome. Please report any bugs that you find `here <https://github.com/xgi-org/xgi/issues>`_.
-Or, even better, fork the repository on `GitHub <https://github.com/xgi-org/xgi>`_ and create a pull request (PR).
-We welcome all changes, big or small, and we will help you make the PR if you are new to `git`
-(just ask on the issue and/or see our `contributing guidelines <https://github.com/xgi-org/xgi/tree/main/CONTRIBUTING.md>`_.
+If you want to contribute to this project, please make sure to read the
+`contributing guidelines <CONTRIBUTING.md>`_.
+We expect respectful and kind interactions by all contributors and users
+as laid out in our `code of conduct <CODE_OF_CONDUCT.md>`_.
+
+The XGI community always welcomes contributions, no matter how small.
+We're happy to help troubleshoot XGI issues you run into,
+assist you if you would like to add functionality or fixes to the codebase,
+or answer any questions you may have.
+
+Some concrete ways that you can get involved:
+
+* **Get XGI updates** by following the XGI `Twitter <https://twitter.com/xginets>`_ account, signing up for our `mailing list <http://eepurl.com/igE6ez>`_, or starring this repository.
+* **Spread the word** when you use XGI by sharing with your colleagues and friends.
+* **Request a new feature or report a bug** by raising a `new issue <https://github.com/xgi-org/xgi/issues/new>`_.
+* **Create a Pull Request (PR)** to address an `open issue <../../issues>`_ or add a feature.
+* **Join our Zulip channel** to be a part of the `daily goings-on of XGI <https://xgi.zulipchat.com/join/7agfwo7dh7jo56ppnk5kc23r/>`_.
 
 How to Cite
 -----------

--- a/requirements/documentation.txt
+++ b/requirements/documentation.txt
@@ -1,6 +1,6 @@
 sphinx~=6.0
 sphinx_copybutton
-sphinx-rtd-theme>=1.0
+sphinx-rtd-theme>=1.2
 numpydoc>=1.1
 pillow>=8.2
 matplotlib>=3.3

--- a/requirements/documentation.txt
+++ b/requirements/documentation.txt
@@ -1,4 +1,4 @@
-sphinx>=7.0
+sphinx~=6.0
 sphinx_copybutton
 pydata-sphinx-theme
 numpydoc>=1.1

--- a/requirements/documentation.txt
+++ b/requirements/documentation.txt
@@ -1,6 +1,6 @@
-sphinx~=4.0
+sphinx>=7.0
 sphinx_copybutton
-sphinx-rtd-theme>=0.4.2
+pydata-sphinx-theme
 numpydoc>=1.1
 pillow>=8.2
 matplotlib>=3.3

--- a/requirements/documentation.txt
+++ b/requirements/documentation.txt
@@ -1,6 +1,6 @@
 sphinx~=6.0
 sphinx_copybutton
-pydata-sphinx-theme
+sphinx-rtd-theme>=1.0
 numpydoc>=1.1
 pillow>=8.2
 matplotlib>=3.3


### PR DESCRIPTION
* Up-version sphinx to v6.xxx
* Up-version sphinx-rtd-theme to >= 1.2 to be [compatible](https://sphinx-rtd-theme.readthedocs.io/en/stable/changelog.html) with Sphinx v6.xxx.
* I added a more organized and concrete contribution guide and eliminated some redundancy in the GH, PyPI, and RTD landing pages. Hopefully this addresses the [reviewer's comments](https://github.com/openjournals/joss-reviews/issues/5162) in our JOSS submission.