### PR TITLE
Add shortest path algorithm

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## v0.6
+* Added functions to compute shortest paths (`single_source_shortest_path` and `shortest_path_length`) [#365](https://github.com/xgi-org/xgi/issues/365) (@acombretrenouard)
 * Added new drawing layouts (`circular_layout`, `spiral_layout`, and `barycenter_kamada_kawai_layout`) [#360](https://github.com/xgi-org/xgi/pull/360) (@thomasrobiglio).
 
 ## v0.5.8

--- a/README.md
+++ b/README.md
@@ -104,3 +104,4 @@ This library may not meet your needs and if this is this case, consider checking
 * [HyperGraphs.jl](https://github.com/lpmdiaz/HyperGraphs.jl): A package in Julia for representing, analyzing, and generating hypergraphs which may be oriented and weighted.
 * [hyperG](https://cran.r-project.org/package=HyperG): A package in R for storing and analyzing hypergraphs
 * [NetworkX](https://networkx.org/): A package in Python for representing, analyzing, and visualizing networks.
+![](![https://github.com/acombretrenouard/xgi.git](![https://github.com/acombretrenouard/xgi.git](https://github.com/acombretrenouard/xgi.git)))

--- a/README.md
+++ b/README.md
@@ -104,4 +104,3 @@ This library may not meet your needs and if this is this case, consider checking
 * [HyperGraphs.jl](https://github.com/lpmdiaz/HyperGraphs.jl): A package in Julia for representing, analyzing, and generating hypergraphs which may be oriented and weighted.
 * [hyperG](https://cran.r-project.org/package=HyperG): A package in R for storing and analyzing hypergraphs
 * [NetworkX](https://networkx.org/): A package in Python for representing, analyzing, and visualizing networks.
-![](![https://github.com/acombretrenouard/xgi.git](![https://github.com/acombretrenouard/xgi.git](https://github.com/acombretrenouard/xgi.git)))

--- a/docs/source/api/algorithms/xgi.algorithms.shortest_path.rst
+++ b/docs/source/api/algorithms/xgi.algorithms.shortest_path.rst
@@ -1,0 +1,11 @@
+﻿xgi.algorithms.shortest_path
+============================
+
+.. currentmodule:: xgi.algorithms.shortest_path
+
+.. automodule:: xgi.algorithms.shortest_path
+   
+   .. rubric:: Functions
+   
+   .. autofunction:: single_source_shortest_path_length
+   .. autofunction:: shortest_path_length

--- a/docs/source/api/utils/xgi.utils.utilities.rst
+++ b/docs/source/api/utils/xgi.utils.utilities.rst
@@ -20,3 +20,4 @@
    .. autofunction:: powerset
    .. autofunction:: update_uid_counter
    .. autofunction:: find_triangles
+   .. autofunction:: min_where

--- a/tests/algorithms/test_shortest_path.py
+++ b/tests/algorithms/test_shortest_path.py
@@ -1,0 +1,32 @@
+import numpy as np
+import pytest
+
+import xgi
+from xgi.exception import XGIError
+
+
+def test_single_source_shortest_path_length(edgelist1):
+    H = xgi.Hypergraph(edgelist1)
+    dists1 = xgi.single_source_shortest_path_length(H, 1)
+    dists4 = xgi.single_source_shortest_path_length(H, 4)
+    dists5 = xgi.single_source_shortest_path_length(H, 5)
+    assert dists1[2] == 1
+    assert dists1[4] == np.inf  # unconnected nodes
+    assert dists5[8] == 2
+
+    return
+
+
+def test_shortest_path_length(edgelist1):
+    H = xgi.Hypergraph(edgelist1)
+    for source, dists in xgi.shortest_path_length(H):
+        # check symetry between 5 and 8
+        if source == 5:
+            assert dists[8] == 2
+        elif source == 8:
+            assert dists[5] == 2
+        # check unconnected nodes
+        elif source == 4:
+            assert dists[1] == np.inf
+            assert dists[4] == 0
+    return

--- a/tests/drawing/test_layout.py
+++ b/tests/drawing/test_layout.py
@@ -143,39 +143,46 @@ def test_pca_transform():
     assert np.allclose(transform1_pos2[2], np.array([-0.02177678, -2.23596193]))
     assert np.allclose(transform1_pos2[3], np.array([4.47192387, -0.04355357]))
 
+
 def test_circular_layout():
     # hypergraph
     H = xgi.random_hypergraph(10, [0.2], seed=1)
     pos = xgi.circular_layout(H)
     assert len(pos) == H.num_nodes
-    
+
     # empty hypergraph
     H = xgi.empty_hypergraph()
     pos = xgi.circular_layout(H)
     assert pos == {}
-    
+
     # single node hypergraph
     H = xgi.trivial_hypergraph()
-    pos = xgi.circular_layout(H, center=[1,1])
-    assert pos[0] == [1,1]
-    
+    pos = xgi.circular_layout(H, center=[1, 1])
+    assert pos[0] == [1, 1]
+
     # test center
     H = xgi.random_hypergraph(10, [0.2], seed=1)
-    center = [2., 1.]
+    center = [2.0, 1.0]
     pos = xgi.circular_layout(H, center=center)
     for i in pos.keys():
-        assert np.round(np.sqrt((pos[i][0]-center[0])**2+(pos[i][1]-center[1])**2), 1) == 1.
-    
+        assert (
+            np.round(
+                np.sqrt((pos[i][0] - center[0]) ** 2 + (pos[i][1] - center[1]) ** 2), 1
+            )
+            == 1.0
+        )
+
     # test radius
     H = xgi.random_hypergraph(10, [0.2], seed=1)
-    pos = xgi.circular_layout(H, radius=2.)
+    pos = xgi.circular_layout(H, radius=2.0)
     for i in pos.keys():
-        assert np.round(np.sqrt(pos[i][0]**2+pos[i][1]**2), 1) == 2. 
-    
+        assert np.round(np.sqrt(pos[i][0] ** 2 + pos[i][1] ** 2), 1) == 2.0
+
     # simplicial complex
     S = xgi.random_flag_complex_d2(10, 0.2)
     pos = xgi.circular_layout(S)
     assert len(pos) == S.num_nodes
+
 
 def test_spiral_layout():
     # hypergraph
@@ -185,22 +192,23 @@ def test_spiral_layout():
     assert pos1.keys() == pos2.keys()
     assert len(pos1) == H.num_nodes
     assert len(pos2) == H.num_nodes
-    
+
     # empty hypergraph
     H = xgi.empty_hypergraph()
     pos = xgi.spiral_layout(H)
     assert pos == {}
-    
+
     # single node hypergraph
     H = xgi.trivial_hypergraph()
-    pos = xgi.spiral_layout(H, center=[1,1])
-    assert pos[0] == [1,1]
+    pos = xgi.spiral_layout(H, center=[1, 1])
+    assert pos[0] == [1, 1]
 
     # simplicial complex
     S = xgi.random_flag_complex_d2(10, 0.2)
     pos = xgi.spiral_layout(S)
     assert len(pos) == S.num_nodes
-    
+
+
 def test_barycenter_kamada_kawai_layout(hypergraph1):
     H = xgi.random_hypergraph(10, [0.2], seed=1)
 

--- a/tests/utils/test_utils.py
+++ b/tests/utils/test_utils.py
@@ -1,4 +1,5 @@
 import networkx as nx
+from numpy import infty
 
 import xgi
 
@@ -64,3 +65,15 @@ def test_find_triangles():
 
     assert triangles == cliques
     assert num_tri == len(cliques)
+
+
+def test_min_where():
+    vals = {"a": 1.0, "b": 0.0, "c": infty, "d": 2.0}
+
+    where = {"a": True, "b": False, "c": True, "d": True}
+    assert (
+        xgi.utils.utilities.min_where(vals, where) == 1
+    )  # replace with xgi.min_where (it seems not to work...)
+
+    where = {"a": False, "b": False, "c": False, "d": False}
+    assert xgi.utils.utilities.min_where(vals, where) == infty

--- a/xgi/algorithms/__init__.py
+++ b/xgi/algorithms/__init__.py
@@ -3,3 +3,4 @@ from .assortativity import *
 from .centrality import *
 from .clustering import *
 from .connected import *
+from .shortest_path import *

--- a/xgi/algorithms/shortest_path.py
+++ b/xgi/algorithms/shortest_path.py
@@ -1,0 +1,103 @@
+"""Algorithms for computing shortest paths in a hypergraph."""
+
+
+import numpy as np
+
+from ..utils import utilities
+
+
+def single_source_shortest_path_length(H, source):
+    """
+    Returns the distances from source to every other node in hypergraph H.
+
+    Parameters
+    ----------
+    H : xgi.Hypergraph
+        Hypergraph on which to compute the distances. Node indexes must be integers.
+    source : int
+        Index of the node from which to compute the distance to every other node.
+
+    Return
+    ------
+    dists : dict
+        Dictionary where keys are node indexes and values are the distances from source.
+    """
+
+    # 1. Mark all nodes unvisited.
+    is_unseen = dict()
+    for node in H.nodes:
+        is_unseen[node] = True
+    n_unseen = len(H.nodes)
+
+    # 2. Assign to every node a tentative distance value.
+    dists = dict()
+    for node in H.nodes:
+        dists[node] = np.infty
+    dists[source] = 0
+    is_unseen[source] = False
+    n_unseen -= 1
+    current = source
+
+    # 3. Consider all of unvisited neighbors of current node and calculate their tentative distances to the current node.
+    stop_condition = False
+    while not stop_condition:
+        for ngb in H.nodes.neighbors(current):
+            if is_unseen[ngb]:
+                increment = 1  # increment = weight(ngb, current) if weighted
+                new_dist = dists[current] + increment
+                if new_dist < dists[ngb]:
+                    dists[ngb] = new_dist
+                else:
+                    pass
+            else:
+                pass
+
+        # 4. Mark the current node as visited and remove it from the unvisited set.
+        is_unseen[current] = False
+        n_unseen -= 1
+
+        # 5. Check for stop condition.
+        stop_condition = (n_unseen == 0) or (
+            utilities.min_where(dists, is_unseen) == np.infty
+        )
+
+        # 6. Otherwise, select the unvisited node that is marked with the smallest tentative distance, set it as the new current node, and go back to step 3.
+        min_val = np.infty
+        argmin = current
+        for node in dists.keys():
+            if is_unseen[node]:
+                if dists[node] < min_val:
+                    min_val = dists[node]
+                    argmin = node
+                else:
+                    pass
+            else:
+                pass
+        current = argmin
+
+    return dists
+
+
+def shortest_path_length(H):
+    """
+    Returns a generator of tuples (source, dists) where dists is a dictonary
+    containing the distances from source to every other node in hypergraph H,
+    for all possible source in H.
+
+    Parameter
+    ---------
+    H : xgi.Hypergraph
+        Hypergraph on which to compute the distances. Node indexes must be integers.
+
+    Return
+    ------
+    paths : generator of tuples
+        Every tuple is of the form (source, dict_of_lengths), for every possible source.
+    """
+
+    for source in H.nodes:
+        dists = single_source_shortest_path_length(H, source)
+        yield (source, dists)
+
+
+## to do : allow for nodes to have an id (dict, etc)...

--- a/xgi/utils/utilities.py
+++ b/xgi/utils/utilities.py
@@ -3,6 +3,8 @@
 from collections import defaultdict
 from itertools import chain, combinations, count
 
+from numpy import infty
+
 from xgi.exception import IDNotFound, XGIError
 
 __all__ = [
@@ -173,3 +175,38 @@ def find_triangles(G):
         if nbr in G[nbr2]
     )
     return [set(tri) for tri in triangles]
+
+
+def min_where(dicty, where):
+    """
+    Finds the minimum value of a dictonary `dicty`. The dictonary `where`
+    indicates which keys to take into account. The minimum is eventualy
+    infinite.
+
+    Parameters
+    ----------
+    dicty : dict
+        Dictionary of values (int, float...) from which to find
+        the minimum.
+    where : dict
+        Dictionary of booleans that has the same keys as `dicty`.
+        The minimum will be searched among the values for which
+        `where[key]` is TRUE.
+
+    Return
+    ------
+    min_val : float or np.Inf
+        Minimum value found in `dicty`. Is set to np.infty if `where` indicated
+        nowhere or if all values are `np.infty`.
+    """
+
+    min_val = infty
+    for key in dicty.keys():
+        if where[key]:
+            if dicty[key] < min_val:
+                min_val = dicty[key]
+            else:
+                pass
+        else:
+            pass
+    return min_val


### PR DESCRIPTION
Related to issue #365.

I added a new file ./xgi/algorithms/shortest_path.py containing two functions (`single_source_shortest_path` and `shortest_path_length`).
There is also a new function in ./xgi/utils/utilities.py.

The functions are structured as in `networkx` and implement the Disjkstra algorithm.
Naming could be improved.

Corresponding test (for algorithms and utilities) and documentation are written. The changelog is up to date as well.
I successfully run `pytest`, `isort .`, `pylint xgi/ --disable all --enable W0611` and `black .`.