### PR TITLE
Katz centrality

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
 ## v0.6
+* Added Katz-centrality algorithm (`katz_centrality`) [#366](https://github.com/xgi-org/xgi/issues/366) (@acombretrenouard).
+
 * Added new drawing layouts (`circular_layout`, `spiral_layout`, and `barycenter_kamada_kawai_layout`) [#360](https://github.com/xgi-org/xgi/pull/360) (@thomasrobiglio).
 
 ## v0.5.8

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,12 @@
 # Changelog
 
-## v0.6
+
+## latest
 
 * Added Katz-centrality algorithm (`katz_centrality`) [#366](https://github.com/xgi-org/xgi/issues/366) (@acombretrenouard).
-* Added functions to compute shortest paths (`single_source_shortest_path` and `shortest_path_length`) [#365](https://github.com/xgi-org/xgi/issues/365) (@acombretrenouard)
+
+## v0.6
+
 * Added new drawing layouts (`circular_layout`, `spiral_layout`, and `barycenter_kamada_kawai_layout`) [#360](https://github.com/xgi-org/xgi/pull/360) (@thomasrobiglio).
 
 ## v0.5.8

--- a/docs/source/api/algorithms/xgi.algorithms.centrality.rst
+++ b/docs/source/api/algorithms/xgi.algorithms.centrality.rst
@@ -11,3 +11,4 @@ xgi.algorithms.centrality
    .. autofunction:: h_eigenvector_centrality
    .. autofunction:: node_edge_centrality
    .. autofunction:: line_vector_centrality
+   .. autofunction:: katz_centrality

--- a/tests/algorithms/test_centrality.py
+++ b/tests/algorithms/test_centrality.py
@@ -158,9 +158,7 @@ def ratio(r, m, kind="CEC"):
         return r ** (1.0 / m)
 
 
-
-
-def test_katz_centrality(edgelist1, edgelist3) :
+def test_katz_centrality(edgelist1, edgelist3):
 
     # test empty hypergraph
     H = xgi.Hypergraph()
@@ -169,17 +167,18 @@ def test_katz_centrality(edgelist1, edgelist3) :
     # test hypergraph with no edge
     H.add_nodes_from([1, 2, 3])
     c, nodedict = xgi.katz_centrality(H, index=True)
-    
+
     # test numerical values
     H = xgi.Hypergraph(edgelist1)
     c, nodedict = xgi.katz_centrality(H, index=True)
-    for key in nodedict.keys() :
-        if nodedict[key] == 4 :
-            assert np.abs(c[key] - 0.) <= 10**-3
-        elif nodedict[key] == 1 :
+    for key in nodedict.keys():
+        if nodedict[key] == 4:
+            assert np.abs(c[key] - 0.0) <= 10**-3
+        elif nodedict[key] == 1:
             assert np.abs(c[key] - 0.2519685) <= 10**-3
-        else : pass
-    
+        else:
+            pass
+
     # test with no index
     H = xgi.Hypergraph(edgelist3)
     c = xgi.katz_centrality(H, index=False)

--- a/tests/algorithms/test_centrality.py
+++ b/tests/algorithms/test_centrality.py
@@ -182,6 +182,6 @@ def test_katz_centrality(edgelist1, edgelist3) :
     
     # test with no index
     H = xgi.Hypergraph(edgelist3)
-    c, nodedict = xgi.katz_centrality(H, index=False)
+    c = xgi.katz_centrality(H, index=False)
 
     return

--- a/tests/algorithms/test_centrality.py
+++ b/tests/algorithms/test_centrality.py
@@ -156,3 +156,32 @@ def ratio(r, m, kind="CEC"):
         return 2 * r * (m - 1) / (np.sqrt(m**2 + 4 * (m - 1) * (r - 1)) + m - 2)
     elif kind == "HEC":
         return r ** (1.0 / m)
+
+
+
+
+def test_katz_centrality(edgelist1, edgelist3) :
+
+    # test empty hypergraph
+    H = xgi.Hypergraph()
+    c, nodedict = xgi.katz_centrality(H, index=True)
+
+    # test hypergraph with no edge
+    H.add_nodes_from([1, 2, 3])
+    c, nodedict = xgi.katz_centrality(H, index=True)
+    
+    # test numerical values
+    H = xgi.Hypergraph(edgelist1)
+    c, nodedict = xgi.katz_centrality(H, index=True)
+    for key in nodedict.keys() :
+        if nodedict[key] == 4 :
+            assert np.abs(c[key] - 0.) <= 10**-3
+        elif nodedict[key] == 1 :
+            assert np.abs(c[key] - 0.2519685) <= 10**-3
+        else : pass
+    
+    # test with no index
+    H = xgi.Hypergraph(edgelist3)
+    c, nodedict = xgi.katz_centrality(H, index=False)
+
+    return

--- a/tests/algorithms/test_centrality.py
+++ b/tests/algorithms/test_centrality.py
@@ -170,11 +170,24 @@ def test_katz_centrality(edgelist1, edgelist3):
     # test numerical values
     H = xgi.Hypergraph(edgelist1)
     c, nodedict = xgi.katz_centrality(H, index=True)
-    res = np.array([0.2519685 , 0.2519685 , 0.2519685 , 0.        , 0.12647448, 0.37746639, 0.25246065, 0.25246065])
+    res = np.array(
+        [
+            0.2519685,
+            0.2519685,
+            0.2519685,
+            0.0,
+            0.12647448,
+            0.37746639,
+            0.25246065,
+            0.25246065,
+        ]
+    )
     assert np.abs(float(np.sum(c - res))) < 1e-3
 
     # test with no index
     H = xgi.Hypergraph(edgelist3)
     c = xgi.katz_centrality(H, index=False)
-    res = np.array([0.34686161, 0.34686161, 0.51894799, 0.51894799, 0.34686161, 0.34686161])
+    res = np.array(
+        [0.34686161, 0.34686161, 0.51894799, 0.51894799, 0.34686161, 0.34686161]
+    )
     assert np.abs(float(np.sum(c - res))) < 1e-3

--- a/tests/algorithms/test_centrality.py
+++ b/tests/algorithms/test_centrality.py
@@ -163,24 +163,23 @@ def test_katz_centrality(edgelist1, edgelist3):
     # test empty hypergraph
     H = xgi.Hypergraph()
     c, nodedict = xgi.katz_centrality(H, index=True)
+    assert c == np.array([])
+    assert nodedict == dict()
 
     # test hypergraph with no edge
     H.add_nodes_from([1, 2, 3])
     c, nodedict = xgi.katz_centrality(H, index=True)
+    res = np.ones(3)/3
+    assert np.abs(float(np.sum(c - res))) < 1e-3
 
     # test numerical values
     H = xgi.Hypergraph(edgelist1)
     c, nodedict = xgi.katz_centrality(H, index=True)
-    for key in nodedict.keys():
-        if nodedict[key] == 4:
-            assert np.abs(c[key] - 0.0) <= 10**-3
-        elif nodedict[key] == 1:
-            assert np.abs(c[key] - 0.2519685) <= 10**-3
-        else:
-            pass
+    res = np.array([0.2519685 , 0.2519685 , 0.2519685 , 0.        , 0.12647448, 0.37746639, 0.25246065, 0.25246065])
+    assert np.abs(float(np.sum(c - res))) < 1e-3
 
     # test with no index
     H = xgi.Hypergraph(edgelist3)
     c = xgi.katz_centrality(H, index=False)
-
-    return
+    res = np.array([0.34686161, 0.34686161, 0.51894799, 0.51894799, 0.34686161, 0.34686161])
+    assert np.abs(float(np.sum(c - res))) < 1e-3

--- a/tests/algorithms/test_centrality.py
+++ b/tests/algorithms/test_centrality.py
@@ -169,7 +169,7 @@ def test_katz_centrality(edgelist1, edgelist3):
     # test hypergraph with no edge
     H.add_nodes_from([1, 2, 3])
     c, nodedict = xgi.katz_centrality(H, index=True)
-    res = np.ones(3)/3
+    res = np.zeros(3)
     assert np.abs(float(np.sum(c - res))) < 1e-3
 
     # test numerical values

--- a/tests/algorithms/test_centrality.py
+++ b/tests/algorithms/test_centrality.py
@@ -164,13 +164,13 @@ def test_katz_centrality(edgelist1, edgelist3):
     H = xgi.Hypergraph()
     H.add_nodes_from([1, 2, 3])
     c, nodedict = xgi.katz_centrality(H, index=True)
-    res = np.zeros(3)
-    assert np.abs(float(np.sum(c - res))) < 1e-3
+    expected_c = np.zeros(3)
+    assert np.allclose(c, expected_c)
 
     # test numerical values
     H = xgi.Hypergraph(edgelist1)
     c, nodedict = xgi.katz_centrality(H, index=True)
-    res = np.array(
+    expected_c = np.array(
         [
             0.2519685,
             0.2519685,
@@ -182,12 +182,12 @@ def test_katz_centrality(edgelist1, edgelist3):
             0.25246065,
         ]
     )
-    assert np.abs(float(np.sum(c - res))) < 1e-3
+    assert np.allclose(c, expected_c)
 
     # test with no index
     H = xgi.Hypergraph(edgelist3)
     c = xgi.katz_centrality(H, index=False)
-    res = np.array(
+    expected_c = np.array(
         [0.34686161, 0.34686161, 0.51894799, 0.51894799, 0.34686161, 0.34686161]
     )
-    assert np.abs(float(np.sum(c - res))) < 1e-3
+    assert np.allclose(c, expected_c)

--- a/tests/algorithms/test_centrality.py
+++ b/tests/algorithms/test_centrality.py
@@ -160,13 +160,8 @@ def ratio(r, m, kind="CEC"):
 
 def test_katz_centrality(edgelist1, edgelist3):
 
-    # test empty hypergraph
-    H = xgi.Hypergraph()
-    c, nodedict = xgi.katz_centrality(H, index=True)
-    assert c == np.array([])
-    assert nodedict == dict()
-
     # test hypergraph with no edge
+    H = xgi.Hypergraph()
     H.add_nodes_from([1, 2, 3])
     c, nodedict = xgi.katz_centrality(H, index=True)
     res = np.zeros(3)

--- a/tests/drawing/test_layout.py
+++ b/tests/drawing/test_layout.py
@@ -143,39 +143,46 @@ def test_pca_transform():
     assert np.allclose(transform1_pos2[2], np.array([-0.02177678, -2.23596193]))
     assert np.allclose(transform1_pos2[3], np.array([4.47192387, -0.04355357]))
 
+
 def test_circular_layout():
     # hypergraph
     H = xgi.random_hypergraph(10, [0.2], seed=1)
     pos = xgi.circular_layout(H)
     assert len(pos) == H.num_nodes
-    
+
     # empty hypergraph
     H = xgi.empty_hypergraph()
     pos = xgi.circular_layout(H)
     assert pos == {}
-    
+
     # single node hypergraph
     H = xgi.trivial_hypergraph()
-    pos = xgi.circular_layout(H, center=[1,1])
-    assert pos[0] == [1,1]
-    
+    pos = xgi.circular_layout(H, center=[1, 1])
+    assert pos[0] == [1, 1]
+
     # test center
     H = xgi.random_hypergraph(10, [0.2], seed=1)
-    center = [2., 1.]
+    center = [2.0, 1.0]
     pos = xgi.circular_layout(H, center=center)
     for i in pos.keys():
-        assert np.round(np.sqrt((pos[i][0]-center[0])**2+(pos[i][1]-center[1])**2), 1) == 1.
-    
+        assert (
+            np.round(
+                np.sqrt((pos[i][0] - center[0]) ** 2 + (pos[i][1] - center[1]) ** 2), 1
+            )
+            == 1.0
+        )
+
     # test radius
     H = xgi.random_hypergraph(10, [0.2], seed=1)
-    pos = xgi.circular_layout(H, radius=2.)
+    pos = xgi.circular_layout(H, radius=2.0)
     for i in pos.keys():
-        assert np.round(np.sqrt(pos[i][0]**2+pos[i][1]**2), 1) == 2. 
-    
+        assert np.round(np.sqrt(pos[i][0] ** 2 + pos[i][1] ** 2), 1) == 2.0
+
     # simplicial complex
     S = xgi.random_flag_complex_d2(10, 0.2)
     pos = xgi.circular_layout(S)
     assert len(pos) == S.num_nodes
+
 
 def test_spiral_layout():
     # hypergraph
@@ -185,22 +192,23 @@ def test_spiral_layout():
     assert pos1.keys() == pos2.keys()
     assert len(pos1) == H.num_nodes
     assert len(pos2) == H.num_nodes
-    
+
     # empty hypergraph
     H = xgi.empty_hypergraph()
     pos = xgi.spiral_layout(H)
     assert pos == {}
-    
+
     # single node hypergraph
     H = xgi.trivial_hypergraph()
-    pos = xgi.spiral_layout(H, center=[1,1])
-    assert pos[0] == [1,1]
+    pos = xgi.spiral_layout(H, center=[1, 1])
+    assert pos[0] == [1, 1]
 
     # simplicial complex
     S = xgi.random_flag_complex_d2(10, 0.2)
     pos = xgi.spiral_layout(S)
     assert len(pos) == S.num_nodes
-    
+
+
 def test_barycenter_kamada_kawai_layout(hypergraph1):
     H = xgi.random_hypergraph(10, [0.2], seed=1)
 

--- a/xgi/algorithms/centrality.py
+++ b/xgi/algorithms/centrality.py
@@ -9,7 +9,7 @@ from scipy.sparse.linalg import eigsh
 from ..classes import convert_labels_to_integers, is_uniform
 from ..convert import to_line_graph
 from ..exception import XGIError
-from ..linalg import clique_motif_matrix, incidence_matrix
+from ..linalg import clique_motif_matrix, incidence_matrix, clique_motif_matrix
 
 __all__ = [
     "clique_eigenvector_centrality",
@@ -368,21 +368,18 @@ def katz_centrality(H, index=False, cutoff=100):
     """
 
     if index:
-        I, nodedict, _ = incidence_matrix(H, index=True)
+        A, nodedict = clique_motif_matrix(H, index=True)
     else:
-        I = incidence_matrix(H, index=False)
+        A = clique_motif_matrix(H, index=False)
 
     N = len(H.nodes)
     M = len(H.edges)
-    if N == 0:  # no nodes
+    if N == 0: # no nodes
         raise XGIError("The Katz-centrality of an empty hypergraph is not defined.")
     elif M == 0:
         c = np.zeros(N)
     else:  # there is at least one edge, both N and M are non-zero
-        A = I.dot(I.transpose()) - np.diag(np.sum(I, axis=1))
-        cutoff = 100
-        alpha = 1 / 2**N  # here, we can replace 2**N by \
-        # scipy.special.comb(N, d) (where d is the max edge size)
+        alpha = 1 / 2**N
         mat = A
         for power in range(1, cutoff):
             mat = alpha * mat.dot(A) + A

--- a/xgi/algorithms/centrality.py
+++ b/xgi/algorithms/centrality.py
@@ -353,8 +353,8 @@ def katz_centrality(H, index=False, cutoff=100):
             = I
     And (I - alpha.A^{t})^{-1} = I + A + alpha * A**2 + alpha**2 * A**3 + ...
     Thus we can use the power serie to compute the Katz-centrality.
-    [2] The Katz-centrality of isolated nodes (i.e. no hyperedges) is not 
-    clearly define. The output in this case could probably be improved.
+    [2] The Katz-centrality of isolated nodes (no hyperedges contains them) is 
+    zero. The Katz-centrality of an empty hypergraph is not defined.
 
     References
     ----------
@@ -372,12 +372,12 @@ def katz_centrality(H, index=False, cutoff=100):
     if N == 0:  # no nodes
         c = np.array([])
     elif M == 0:
-        c = np.ones(N) / N
+        c = np.zeros(N)
     else:  # there is at least one edge, both N and M are non-zero
         A = I.dot(I.transpose()) - np.diag(np.sum(I, axis=1))
         cutoff = 100
-        alpha = 1 / 2**N  # here, we can replace 2**N by scipy.special.comb(N, d) \
-        # (where d is the max edge size)
+        alpha = 1 / 2**N  # here, we can replace 2**N by \
+        # scipy.special.comb(N, d) (where d is the max edge size)
         mat = A
         for power in range(1, cutoff):
             mat = alpha * mat.dot(A) + A

--- a/xgi/algorithms/centrality.py
+++ b/xgi/algorithms/centrality.py
@@ -16,6 +16,8 @@ __all__ = [
     "h_eigenvector_centrality",
     "node_edge_centrality",
     "line_vector_centrality",
+    "line_vector_centrality",
+    "katz_centrality",
 ]
 
 
@@ -329,6 +331,9 @@ def katz_centrality(H, index=False, cutoff=100) :
     -------
     c : np.ndarray
         Vector of the node centralities, sorted by the node indexes.
+    nodedict : dict
+        If index is set to True, nodedict will contain the nodes ids, keyed by their indice in vector c.
+        <c[key]> will be the centrality of node <nodedict[key]>.
 
     Note
     ----

--- a/xgi/algorithms/centrality.py
+++ b/xgi/algorithms/centrality.py
@@ -311,12 +311,9 @@ def line_vector_centrality(H):
     return vc
 
 
-
-
-
-def katz_centrality(H, index=False, cutoff=100) :
+def katz_centrality(H, index=False, cutoff=100):
     """Returns the Katz-centrality vector of hypergraph H.
-    
+
     Parameters
     ----------
     H : xgi.Hypergraph
@@ -351,37 +348,36 @@ def katz_centrality(H, index=False, cutoff=100) :
 
     References
     ----------
-    See https://en.wikipedia.org/wiki/Katz_centrality#Alpha_centrality (visited May 20 2023) for a clear 
+    See https://en.wikipedia.org/wiki/Katz_centrality#Alpha_centrality (visited May 20 2023) for a clear
     definition of Katz centrality.
     """
 
-    if index :
+    if index:
         I, nodedict, _ = incidence_matrix(H, index=True)
-    else :
+    else:
         I = incidence_matrix(H, index=False)
 
     N = len(H.nodes)
     M = len(H.edges)
-    if N == 0 : # no nodes
+    if N == 0:  # no nodes
         c = np.array([])
-    elif M == 0 :
+    elif M == 0:
         c = np.ones(N) / N
-    else : # there is at least one edge, both N and M are non-zero
+    else:  # there is at least one edge, both N and M are non-zero
         A = I.dot(I.transpose()) - np.diag(np.sum(I, axis=1))
         cutoff = 100
-        alpha = 1/2**N # here, we can replace 2**N by scipy.special.comb(N, d) \
-                       # (where d is the max edge size)
+        alpha = 1 / 2**N  # here, we can replace 2**N by scipy.special.comb(N, d) \
+        # (where d is the max edge size)
         mat = A
-        for power in range(1, cutoff) :
+        for power in range(1, cutoff):
             mat = alpha * mat.dot(A) + A
-        u = 1/N * np.ones(N)
+        u = 1 / N * np.ones(N)
         c = mat.dot(u)
-    
-    if index :
-        return c, nodedict
-    else :
-        return c
 
+    if index:
+        return c, nodedict
+    else:
+        return c
 
 
 # to do : maybe add something to measure convergence in the power-serie in katz_centrality

--- a/xgi/algorithms/centrality.py
+++ b/xgi/algorithms/centrality.py
@@ -352,11 +352,11 @@ def katz_centrality(H, index=False, cutoff=100):
     Where A is the adjency matrix of the the (hyper)graph.
     Since A^{t} = A for undirected graphs (our case), we have :
         (I + A + alpha * A**2 + alpha**2 * A**3 + ...) * (I - alpha.A^{t})
-            = (I + A + alpha * A**2 + alpha**2 * A**3 + ...) * (I - alpha.A)
-            = (I + A + alpha * A**2 + alpha**2 * A**3 + ...) - A - alpha * A**2
-                - alpha**2 * A**3 - alpha**3 * A**4 - ...
+            = (I + A + alpha.A**2 + alpha**2.A**3 + ...) * (I - alpha.A)
+            = (I + A + alpha.A**2 + alpha**2.A**3 + ...) - A - alpha.A**2
+                - alpha**2.A**3 - alpha**3.A**4 - ...
             = I
-    And (I - alpha.A^{t})^{-1} = I + A + alpha * A**2 + alpha**2 * A**3 + ...
+    And (I - alpha.A^{t})^{-1} = I + A + alpha.A**2 + alpha**2.A**3 + ...
     Thus we can use the power serie to compute the Katz-centrality.
     [2] The Katz-centrality of isolated nodes (no hyperedges contains them) is
     zero. The Katz-centrality of an empty hypergraph is not defined.

--- a/xgi/algorithms/centrality.py
+++ b/xgi/algorithms/centrality.py
@@ -313,42 +313,53 @@ def line_vector_centrality(H):
 def katz_centrality(H, index=False, cutoff=100):
     """Returns the Katz-centrality vector of hypergraph H.
 
+    The Katz-centrality measures the relative importance of a node by counting 
+    how many distinct walks start from it. The longer the walk is the smaller 
+    its contribution will be (attenuation factor `alpha`). 
+    Initialy defined for graphs, the Katz-centrality is here generalized to 
+    hypergraphs using the most basic definition of neighbors : two nodes that 
+    share an hyperedge.
+
     Parameters
     ----------
     H : xgi.Hypergraph
         Hypergraph on which to compute the Kayz-centralities.
     index : bool
-        If set to True, will return a dictionary mapping each vector index to a node.
+        If set to `True`, will return a dictionary mapping each vector index to a 
+        node. Default value is `False`.
     cutoff : int
-        Power at which to stop the computation A + alpha * A**2 + alpha**2 * A**3 + ...
-        Default is 100.
+        Power at which to stop the serie A + alpha * A**2 + alpha**2 * A**3 + ..
+        Default value is 100.
 
     Returns
     -------
     c : np.ndarray
         Vector of the node centralities, sorted by the node indexes.
     nodedict : dict
-        If index is set to True, nodedict will contain the nodes ids, keyed by their indice in vector c.
-        <c[key]> will be the centrality of node <nodedict[key]>.
+        If index is set to True, nodedict will contain the nodes ids, keyed by 
+        their indice in vector `c`.
+        Thus, `c[key]` will be the centrality of node `nodedict[key]`.
 
-    Note
-    ----
+    Notes
+    -----
     [1] The Katz-centrality is defined as :
         c = [(I - alpha.A^{t})^{-1} - I] • (1, 1, ..., 1)
     Where A is the adjency matrix of the the (hyper)graph.
     Since A^{t} = A for undirected graphs (our case), we have :
-        (I + A + alpha * A**2 + alpha**2 * A**3 + ...) * (I - alpha.A^{t}) = (I + A + alpha * A**2 + alpha**2 * A**3 + ...) * (I - alpha.A)
-                                                                           = (I + A + alpha * A**2 + alpha**2 * A**3 + ...) - A - alpha * A**2 - alpha**2 * A**3 - alpha**3 * A**3 - ...
-                                                                           = I
+        (I + A + alpha * A**2 + alpha**2 * A**3 + ...) * (I - alpha.A^{t})
+            = (I + A + alpha * A**2 + alpha**2 * A**3 + ...) * (I - alpha.A)
+            = (I + A + alpha * A**2 + alpha**2 * A**3 + ...) - A - alpha * A**2 
+                - alpha**2 * A**3 - alpha**3 * A**4 - ...
+            = I
     And (I - alpha.A^{t})^{-1} = I + A + alpha * A**2 + alpha**2 * A**3 + ...
     Thus we can use the power serie to compute the Katz-centrality.
-    [2] The Katz-centrality of isolated nodes (i.e. no hyperedges) is not clearly define.
-    The output in this case could probably be improved.
+    [2] The Katz-centrality of isolated nodes (i.e. no hyperedges) is not 
+    clearly define. The output in this case could probably be improved.
 
     References
     ----------
-    See https://en.wikipedia.org/wiki/Katz_centrality#Alpha_centrality (visited May 20 2023) for a clear
-    definition of Katz centrality.
+    See https://en.wikipedia.org/wiki/Katz_centrality#Alpha_centrality (visited 
+    May 20 2023) for a clear definition of Katz centrality.
     """
 
     if index:

--- a/xgi/algorithms/centrality.py
+++ b/xgi/algorithms/centrality.py
@@ -313,11 +313,11 @@ def line_vector_centrality(H):
 def katz_centrality(H, index=False, cutoff=100):
     """Returns the Katz-centrality vector of a non-empty hypergraph H.
 
-    The Katz-centrality measures the relative importance of a node by counting 
-    how many distinct walks start from it. The longer the walk is the smaller 
-    its contribution will be (attenuation factor `alpha`). 
-    Initialy defined for graphs, the Katz-centrality is here generalized to 
-    hypergraphs using the most basic definition of neighbors : two nodes that 
+    The Katz-centrality measures the relative importance of a node by counting
+    how many distinct walks start from it. The longer the walk is the smaller
+    its contribution will be (attenuation factor `alpha`).
+    Initialy defined for graphs, the Katz-centrality is here generalized to
+    hypergraphs using the most basic definition of neighbors : two nodes that
     share an hyperedge.
 
     Parameters
@@ -325,7 +325,7 @@ def katz_centrality(H, index=False, cutoff=100):
     H : xgi.Hypergraph
         Hypergraph on which to compute the Kayz-centralities.
     index : bool
-        If set to `True`, will return a dictionary mapping each vector index to a 
+        If set to `True`, will return a dictionary mapping each vector index to a
         node. Default value is `False`.
     cutoff : int
         Power at which to stop the serie A + alpha * A**2 + alpha**2 * A**3 + ..
@@ -336,7 +336,7 @@ def katz_centrality(H, index=False, cutoff=100):
     c : np.ndarray
         Vector of the node centralities, sorted by the node indexes.
     nodedict : dict
-        If index is set to True, nodedict will contain the nodes ids, keyed by 
+        If index is set to True, nodedict will contain the nodes ids, keyed by
         their indice in vector `c`.
         Thus, `c[key]` will be the centrality of node `nodedict[key]`.
 
@@ -353,17 +353,17 @@ def katz_centrality(H, index=False, cutoff=100):
     Since A^{t} = A for undirected graphs (our case), we have :
         (I + A + alpha * A**2 + alpha**2 * A**3 + ...) * (I - alpha.A^{t})
             = (I + A + alpha * A**2 + alpha**2 * A**3 + ...) * (I - alpha.A)
-            = (I + A + alpha * A**2 + alpha**2 * A**3 + ...) - A - alpha * A**2 
+            = (I + A + alpha * A**2 + alpha**2 * A**3 + ...) - A - alpha * A**2
                 - alpha**2 * A**3 - alpha**3 * A**4 - ...
             = I
     And (I - alpha.A^{t})^{-1} = I + A + alpha * A**2 + alpha**2 * A**3 + ...
     Thus we can use the power serie to compute the Katz-centrality.
-    [2] The Katz-centrality of isolated nodes (no hyperedges contains them) is 
+    [2] The Katz-centrality of isolated nodes (no hyperedges contains them) is
     zero. The Katz-centrality of an empty hypergraph is not defined.
 
     References
     ----------
-    See https://en.wikipedia.org/wiki/Katz_centrality#Alpha_centrality (visited 
+    See https://en.wikipedia.org/wiki/Katz_centrality#Alpha_centrality (visited
     May 20 2023) for a clear definition of Katz centrality.
     """
 
@@ -375,7 +375,7 @@ def katz_centrality(H, index=False, cutoff=100):
     N = len(H.nodes)
     M = len(H.edges)
     if N == 0:  # no nodes
-        raise XGIError('The Katz-centrality of an empty hypergraph is not defined.')
+        raise XGIError("The Katz-centrality of an empty hypergraph is not defined.")
     elif M == 0:
         c = np.zeros(N)
     else:  # there is at least one edge, both N and M are non-zero
@@ -393,4 +393,3 @@ def katz_centrality(H, index=False, cutoff=100):
         return c, nodedict
     else:
         return c
-

--- a/xgi/algorithms/centrality.py
+++ b/xgi/algorithms/centrality.py
@@ -16,7 +16,6 @@ __all__ = [
     "h_eigenvector_centrality",
     "node_edge_centrality",
     "line_vector_centrality",
-    "line_vector_centrality",
     "katz_centrality",
 ]
 

--- a/xgi/algorithms/centrality.py
+++ b/xgi/algorithms/centrality.py
@@ -311,7 +311,7 @@ def line_vector_centrality(H):
 
 
 def katz_centrality(H, index=False, cutoff=100):
-    """Returns the Katz-centrality vector of hypergraph H.
+    """Returns the Katz-centrality vector of a non-empty hypergraph H.
 
     The Katz-centrality measures the relative importance of a node by counting 
     how many distinct walks start from it. The longer the walk is the smaller 
@@ -339,6 +339,11 @@ def katz_centrality(H, index=False, cutoff=100):
         If index is set to True, nodedict will contain the nodes ids, keyed by 
         their indice in vector `c`.
         Thus, `c[key]` will be the centrality of node `nodedict[key]`.
+
+    Raises
+    ------
+    XGIError
+        If the hypergraph is empty.
 
     Notes
     -----
@@ -370,7 +375,7 @@ def katz_centrality(H, index=False, cutoff=100):
     N = len(H.nodes)
     M = len(H.edges)
     if N == 0:  # no nodes
-        c = np.array([])
+        raise XGIError('The Katz-centrality of an empty hypergraph is not defined.')
     elif M == 0:
         c = np.zeros(N)
     else:  # there is at least one edge, both N and M are non-zero
@@ -389,5 +394,3 @@ def katz_centrality(H, index=False, cutoff=100):
     else:
         return c
 
-
-# to do : maybe add something to measure convergence in the power-serie in katz_centrality

--- a/xgi/algorithms/centrality.py
+++ b/xgi/algorithms/centrality.py
@@ -316,7 +316,7 @@ def katz_centrality(H, index=False, cutoff=100):
     Parameters
     ----------
     H : xgi.Hypergraph
-        Hypergraph on which to compute the alpha centralities.
+        Hypergraph on which to compute the Kayz-centralities.
     index : bool
         If set to True, will return a dictionary mapping each vector index to a node.
     cutoff : int

--- a/xgi/algorithms/shortest_path.py
+++ b/xgi/algorithms/shortest_path.py
@@ -5,6 +5,8 @@ import numpy as np
 
 from ..utils import utilities
 
+__all__ = ["single_source_shortest_path_length", "shortest_path_length"]
+
 
 def single_source_shortest_path_length(H, source):
     """


### PR DESCRIPTION
New Katz centrality algorithms, computed with a power-series over the adjacency matrix.
Another option would be a direct matrix inversion (computationally harder ?).

The usual contribution pipeline runs without errors (`pytest`, `isort .`, etc...).