### PR TITLE
update index.rst to have dihypergraph in quick references

### DIFF
--- a/docs/source/api/classes/xgi.classes.dihypergraph.DiHypergraph.rst
+++ b/docs/source/api/classes/xgi.classes.dihypergraph.DiHypergraph.rst
@@ -4,8 +4,7 @@
 .. currentmodule:: xgi.classes.dihypergraph
 
 .. warning::
-    This is an experimental module. It has been thoroughly tested in development
-    but has not been used in research. It is not yet stable and may change in the future.
+    This is an experimental module. It is not yet stable and may change in the future.
 .. autoclass:: DiHypergraph
    :show-inheritance:
    :members:

--- a/docs/source/api/classes/xgi.classes.dihypergraph.DiHypergraph.rst
+++ b/docs/source/api/classes/xgi.classes.dihypergraph.DiHypergraph.rst
@@ -3,6 +3,9 @@
 
 .. currentmodule:: xgi.classes.dihypergraph
 
+.. warning::
+    This is an experimental module. It has been throughly tested in development
+    but has not been used in research. It is not yet stable and may change in the future.
 .. autoclass:: DiHypergraph
    :show-inheritance:
    :members:

--- a/docs/source/api/classes/xgi.classes.dihypergraph.DiHypergraph.rst
+++ b/docs/source/api/classes/xgi.classes.dihypergraph.DiHypergraph.rst
@@ -4,7 +4,7 @@
 .. currentmodule:: xgi.classes.dihypergraph
 
 .. warning::
-    This is an experimental module. It has been throughly tested in development
+    This is an experimental module. It has been thoroughly tested in development
     but has not been used in research. It is not yet stable and may change in the future.
 .. autoclass:: DiHypergraph
    :show-inheritance:

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -23,6 +23,7 @@
 
    Hypergraph class <api/classes/xgi.classes.hypergraph.Hypergraph.rst>
    Simplicial Complex class <api/classes/xgi.classes.simplicialcomplex.SimplicialComplex.rst>
+   Directed Hypergraph class <api/classes/xgi.classes.dihypergraph.DiHypergraph>
 
 .. toctree::
    :maxdepth: 2


### PR DESCRIPTION
I noticed that the DH does not appear in the quick references, I think this might fix it (but I'm not familiar at all with how Sphinx works, etc. so pls check it). 