### PR TITLE
Convert from simplex dict to SC

### DIFF
--- a/tests/classes/test_simplicialcomplex.py
+++ b/tests/classes/test_simplicialcomplex.py
@@ -10,18 +10,18 @@ def test_constructor(edgelist5, dict5, incidence5, dataframe5):
     S_list = xgi.SimplicialComplex(edgelist5)
     S_df = xgi.SimplicialComplex(dataframe5)
     S_sc = xgi.SimplicialComplex(S_list)
+    S_dict = xgi.SimplicialComplex(dict5)
 
-    with pytest.raises(XGIError):
-        _ = xgi.SimplicialComplex(dict5)
     with pytest.raises(XGIError):
         _ = xgi.SimplicialComplex(incidence5)
 
-    assert set(S_list.nodes) == set(S_df.nodes) == set(S_sc.nodes)
-    assert set(S_list.edges) == set(S_df.edges) == set(S_sc.edges)
+    assert set(S_list.nodes) == set(S_df.nodes) == set(S_sc.nodes) == set(S_dict.nodes)
+    assert set(S_list.edges) == set(S_df.edges) == set(S_sc.edges) == set(S_dict.edges)
     assert (
         set(S_list.edges.members(0))
         == set(S_df.edges.members(0))
         == set(S_sc.edges.members(0))
+        == set(S_dict.edges.members(0))
     )
 
     with pytest.raises(XGIError):

--- a/xgi/classes/hypergraph.py
+++ b/xgi/classes/hypergraph.py
@@ -35,7 +35,8 @@ class Hypergraph:
         * hyperedge dictionary
         * 2-column Pandas dataframe (bipartite edges)
         * Scipy/Numpy incidence matrix
-        * Hypergraph object.
+        * Hypergraph object
+        * SimplicialComplex object
 
     **attr : dict, optional
         Attributes to add to the hypergraph as key, value pairs.

--- a/xgi/classes/simplicialcomplex.py
+++ b/xgi/classes/simplicialcomplex.py
@@ -46,6 +46,7 @@ class SimplicialComplex(Hypergraph):
         * 2-column Pandas dataframe (bipartite edges)
         * Scipy/Numpy incidence matrix
         * SimplicialComplex object.
+        * Hypergraph object
 
     **attr : dict, optional
         Attributes to add to the simplicial complex as key, value pairs.

--- a/xgi/classes/simplicialcomplex.py
+++ b/xgi/classes/simplicialcomplex.py
@@ -45,7 +45,7 @@ class SimplicialComplex(Hypergraph):
         * simplex dictionary
         * 2-column Pandas dataframe (bipartite edges)
         * Scipy/Numpy incidence matrix
-        * SimplicialComplex object.
+        * SimplicialComplex object
         * Hypergraph object
 
     **attr : dict, optional

--- a/xgi/convert.py
+++ b/xgi/convert.py
@@ -859,13 +859,13 @@ def from_simplex_dict(d, create_using=None):
     d : dict
         A dictionary where the keys are simplex IDs and the values
         are containers of nodes specifying the simplices.
-    create_using : Hypergraph constructor, optional
-        The hypergraph object to add the data to, by default None
+    create_using : SimplicialComplex constructor, optional
+        The simplicial complex object to add the data to, by default None
 
     Returns
     -------
-    Hypergraph object
-        The constructed hypergraph object
+    SimplicialComplex object
+        The constructed simplicial complex object
 
     """
     SC = empty_simplicial_complex(create_using)

--- a/xgi/convert.py
+++ b/xgi/convert.py
@@ -846,6 +846,7 @@ def dict_to_hypergraph(data, nodetype=None, edgetype=None, max_order=None):
 
     return H
 
+
 def from_simplex_dict(d, create_using=None):
     """Creates a Simplicial Complex from a dictionary of simplices,
     if the subfaces of existing simplices are not given in the dict

--- a/xgi/convert.py
+++ b/xgi/convert.py
@@ -308,8 +308,9 @@ def convert_to_simplicial_complex(data, create_using=None):
             return convert_to_simplicial_complex(result)
 
     elif isinstance(data, dict):
-        # edge dict in the form we need
-        raise XGIError("Cannot generate SimplicialComplex from simplex dictionary")
+        result = from_simplex_dict(data, create_using)
+        if not isinstance(create_using, SimplicialComplex):
+            return convert_to_simplicial_complex(result)
     elif isinstance(
         data,
         (
@@ -844,3 +845,27 @@ def dict_to_hypergraph(data, nodetype=None, edgetype=None, max_order=None):
         raise XGIError("Failed to import edge attributes.") from e
 
     return H
+
+def from_simplex_dict(d, create_using=None):
+    """Creates a Simplicial Complex from a dictionary of simplices,
+    if the subfaces of existing simplices are not given in the dict
+    then the function add them with integer IDs.
+
+
+    Parameters
+    ----------
+    d : dict
+        A dictionary where the keys are simplex IDs and the values
+        are containers of nodes specifying the simplices.
+    create_using : Hypergraph constructor, optional
+        The hypergraph object to add the data to, by default None
+
+    Returns
+    -------
+    Hypergraph object
+        The constructed hypergraph object
+
+    """
+    SC = empty_simplicial_complex(create_using)
+    SC.add_simplices_from((members, uid) for uid, members in d.items())
+    return SC

--- a/xgi/convert.py
+++ b/xgi/convert.py
@@ -40,6 +40,7 @@ __all__ = [
     "to_bipartite_graph",
     "dict_to_hypergraph",
     "to_line_graph",
+    "from_simplex_dict",
 ]
 
 

--- a/xgi/convert.py
+++ b/xgi/convert.py
@@ -851,7 +851,7 @@ def dict_to_hypergraph(data, nodetype=None, edgetype=None, max_order=None):
 def from_simplex_dict(d, create_using=None):
     """Creates a Simplicial Complex from a dictionary of simplices,
     if the subfaces of existing simplices are not given in the dict
-    then the function add them with integer IDs.
+    then the function adds them with integer IDs.
 
 
     Parameters


### PR DESCRIPTION
This should resolve #330 (the ability for the SC constructor to handle a HG was already implemented, this PR is about https://github.com/xgi-org/xgi/issues/330#issuecomment-1503337363).

I added a new function `from_simplex_dict` that takes a dict in the form: `{edge_id: members, ...}` and returns a SC. If the subfaces of existing simplices are not given in the dict then the function adds them with integer IDs.

<img width="788" alt="Screenshot 2023-06-12 alle 19 48 15" src="https://github.com/xgi-org/xgi/assets/83019028/f1e1aeb9-241e-42e2-bc0a-1756e26ddde8">
