### PR TITLE
fix: HG using SC as data

### DIFF
--- a/tests/classes/test_hypergraph.py
+++ b/tests/classes/test_hypergraph.py
@@ -44,7 +44,7 @@ def test_constructor(edgelist5, dict5, incidence5, dataframe5):
     H_sc = xgi.Hypergraph(SC)
 
     assert set(H_sc.nodes) == set(SC.nodes)
-    assert set(H_sc.edges) == set(SC.edges)
+    assert set(H_sc.edges.members()) == set(SC.edges.members())
 
 
 def test_hypergraph_attrs():

--- a/tests/classes/test_hypergraph.py
+++ b/tests/classes/test_hypergraph.py
@@ -42,7 +42,7 @@ def test_constructor(edgelist5, dict5, incidence5, dataframe5):
 
     SC = xgi.SimplicialComplex(edgelist5)
     H_sc = xgi.Hypergraph(SC)
-    
+
     assert set(H_sc.nodes) == set(SC.nodes)
     assert set(H_sc.edges) == set(SC.edges)
 

--- a/tests/classes/test_hypergraph.py
+++ b/tests/classes/test_hypergraph.py
@@ -40,6 +40,11 @@ def test_constructor(edgelist5, dict5, incidence5, dataframe5):
     with pytest.raises(XGIError):
         xgi.Hypergraph(1)
 
+    SC = xgi.SimplicialComplex(edgelist5)
+    H_sc = xgi.Hypergraph(SC)
+    assert set(H_sc.nodes) == set(SC.nodes)
+    assert set(H_sc.edges) == set(SC.edges)
+
 
 def test_hypergraph_attrs():
     H = xgi.Hypergraph()

--- a/tests/classes/test_hypergraph.py
+++ b/tests/classes/test_hypergraph.py
@@ -42,6 +42,7 @@ def test_constructor(edgelist5, dict5, incidence5, dataframe5):
 
     SC = xgi.SimplicialComplex(edgelist5)
     H_sc = xgi.Hypergraph(SC)
+    
     assert set(H_sc.nodes) == set(SC.nodes)
     assert set(H_sc.edges) == set(SC.edges)
 

--- a/tests/classes/test_hypergraph.py
+++ b/tests/classes/test_hypergraph.py
@@ -44,7 +44,7 @@ def test_constructor(edgelist5, dict5, incidence5, dataframe5):
     H_sc = xgi.Hypergraph(SC)
 
     assert set(H_sc.nodes) == set(SC.nodes)
-    assert set(H_sc.edges.members()) == set(SC.edges.members())
+    assert H_sc.edges.members() == SC.edges.members()
 
 
 def test_hypergraph_attrs():

--- a/tests/classes/test_simplicialcomplex.py
+++ b/tests/classes/test_simplicialcomplex.py
@@ -27,6 +27,13 @@ def test_constructor(edgelist5, dict5, incidence5, dataframe5):
     with pytest.raises(XGIError):
         xgi.SimplicialComplex(1)
 
+    H = xgi.Hypergraph(edgelist5)
+    S_h = xgi.SimplicialComplex(H)
+
+    assert set(S_h.nodes) == set(H.nodes) == set(S_list.nodes)
+    assert set(S_h.edges) == set(S_list.edges)
+    
+
 
 def test_string():
     S1 = xgi.SimplicialComplex()

--- a/tests/classes/test_simplicialcomplex.py
+++ b/tests/classes/test_simplicialcomplex.py
@@ -32,7 +32,6 @@ def test_constructor(edgelist5, dict5, incidence5, dataframe5):
 
     assert set(S_h.nodes) == set(H.nodes) == set(S_list.nodes)
     assert set(S_h.edges) == set(S_list.edges)
-    
 
 
 def test_string():

--- a/tests/classes/test_simplicialcomplex.py
+++ b/tests/classes/test_simplicialcomplex.py
@@ -31,8 +31,8 @@ def test_constructor(edgelist5, dict5, incidence5, dataframe5):
     S_h = xgi.SimplicialComplex(H)
 
     assert set(S_h.nodes) == set(H.nodes) == set(S_list.nodes)
-    assert set(S_h.edges.members()) == set(S_list.edges.members())
-    assert set(H.edges.members()) <= set(S_h.edges.members()) # check it's a subset
+    assert S_h.edges.members() == S_list.edges.members()
+    assert H.edges.members() <= S_h.edges.members() # check it's a subset
 
 
 def test_string():

--- a/tests/classes/test_simplicialcomplex.py
+++ b/tests/classes/test_simplicialcomplex.py
@@ -31,7 +31,8 @@ def test_constructor(edgelist5, dict5, incidence5, dataframe5):
     S_h = xgi.SimplicialComplex(H)
 
     assert set(S_h.nodes) == set(H.nodes) == set(S_list.nodes)
-    assert set(S_h.edges) == set(S_list.edges)
+    assert set(S_h.edges.members()) == set(S_list.edges.members())
+    assert set(H.edges.members()) <= set(S_h.edges.members()) # check it's a subset
 
 
 def test_string():

--- a/tests/test_convert.py
+++ b/tests/test_convert.py
@@ -24,7 +24,7 @@ def test_convert_simplicial_complex_to_hypergraph():
     H = xgi.convert_to_hypergraph(SC)
     assert isinstance(H, xgi.Hypergraph)
     assert SC.nodes == H.nodes
-    assert SC.edges.maximal().members() == H.edges.members()
+    assert SC.edges.members() == H.edges.members()
 
 
 def test_convert_list_to_hypergraph(edgelist2):

--- a/xgi/convert.py
+++ b/xgi/convert.py
@@ -69,6 +69,10 @@ def convert_to_hypergraph(data, create_using=None):
     Hypergraph object
         A hypergraph constructed from the data
 
+    See Also
+    --------
+    from_max_simplices : Constructs a hypergraph from the maximal simplices of a simplicial complex.
+
     """
     if data is None:
         return empty_hypergraph(create_using)
@@ -89,9 +93,6 @@ def convert_to_hypergraph(data, create_using=None):
         H._hypergraph = deepcopy(data._hypergraph)
         if not isinstance(create_using, DiHypergraph):
             return H
-
-    elif isinstance(data, SimplicialComplex) and create_using is None:
-        return from_max_simplices(data)
 
     elif isinstance(data, SimplicialComplex):
         H = empty_hypergraph(create_using)

--- a/xgi/convert.py
+++ b/xgi/convert.py
@@ -92,7 +92,7 @@ def convert_to_hypergraph(data, create_using=None):
 
     elif isinstance(data, SimplicialComplex) and create_using is None:
         return from_max_simplices(data)
-    
+
     elif isinstance(data, SimplicialComplex):
         H = empty_hypergraph(create_using)
         H.add_nodes_from((n, attr) for n, attr in data.nodes.items())

--- a/xgi/convert.py
+++ b/xgi/convert.py
@@ -90,8 +90,16 @@ def convert_to_hypergraph(data, create_using=None):
         if not isinstance(create_using, DiHypergraph):
             return H
 
-    elif isinstance(data, SimplicialComplex):
+    elif isinstance(data, SimplicialComplex) and create_using is None:
         return from_max_simplices(data)
+    
+    elif isinstance(data, SimplicialComplex):
+        H = empty_hypergraph(create_using)
+        H.add_nodes_from((n, attr) for n, attr in data.nodes.items())
+        ee = data.edges
+        H.add_edges_from((ee.members(e), e, deepcopy(attr)) for e, attr in ee.items())
+        H._hypergraph = deepcopy(data._hypergraph)
+        return H
 
     elif isinstance(data, list):
         # edge list


### PR DESCRIPTION
Related to #398. The bug was coming from the condition I had set in the `convert_to_hypergraph()` in PR #345 (sry 😢). Now it should be fixed. 

There are two issues related to this:

1. The constructors `xgi.Hypergraph(SC)` and `xgi.SimplicialComplex(H)` are *not* tested! 
2. How it is implemented now if I call the cover `convert_to_hypergraph()` as a standalone with a SC as an object I get back the HG constructed from the maximal simplices of the SC, if instead, I call it via the constructor I get a HG in which every simplex in the SC becomes an edge. Is this ok or we want to change it?

For me it is intuitive to have the standalone convert give only the maximal simplices but I guess this is debatable.
![Screenshot 2023-06-13 alle 12 24 22](https://github.com/xgi-org/xgi/assets/83019028/7ae99a1f-b5f0-4c90-b367-de4d6ac8c83f)
  