### PR TITLE
Fix IDView.ids type

### DIFF
--- a/tests/classes/test_reportviews.py
+++ b/tests/classes/test_reportviews.py
@@ -331,3 +331,16 @@ def test_maximal(edgelist5, edgelist8):
     # try strict=True
     m = H.edges.maximal(strict=True)
     assert set(m) == {5}
+
+
+def test_ids_type(edgelist5):
+    H = xgi.Hypergraph(edgelist5)
+    assert H.edges.ids == {0, 1, 2, 3}
+    assert H.edges([0, 1, 2, 3]).ids == {0, 1, 2, 3}
+    assert H.edges({0, 1, 2, 3}).ids == {0, 1, 2, 3}
+
+
+def test_ids_are_immutable(edgelist5):
+    H = xgi.Hypergraph(edgelist5)
+    H.edges.ids.add(42)
+    assert H.edges.ids == {0, 1, 2, 3}

--- a/tests/linalg/test_matrix.py
+++ b/tests/linalg/test_matrix.py
@@ -486,23 +486,22 @@ def test_boundary_matrix(edgelist4):
     facedict1 = {k: v for v, k in facedict1.items()}
     tetdict1 = {k: v for v, k in tetdict1.items()}
 
-    iddict = S1.edges.ids
-    iddict = {simplex: v for v, simplex in iddict.items()}
+    members_to_id = {simplex: v for v, simplex in S1.edges.members(dtype=dict).items()}
 
-    i123 = facedict1[iddict[frozenset([1, 2, 3])]]
-    i2345 = tetdict1[iddict[frozenset([2, 3, 4, 5])]]
-    i345 = facedict1[iddict[frozenset([3, 4, 5])]]
-    i245 = facedict1[iddict[frozenset([2, 4, 5])]]
-    i12 = edgedict1[iddict[frozenset([1, 2])]]
-    i24 = edgedict1[iddict[frozenset([2, 4])]]
-    i34 = edgedict1[iddict[frozenset([3, 4])]]
-    i235 = facedict1[iddict[frozenset([2, 3, 5])]]
-    i23 = edgedict1[iddict[frozenset([2, 3])]]
-    i45 = edgedict1[iddict[frozenset([4, 5])]]
-    i234 = facedict1[iddict[frozenset([2, 3, 4])]]
-    i25 = edgedict1[iddict[frozenset([2, 5])]]
-    i13 = edgedict1[iddict[frozenset([1, 3])]]
-    i35 = edgedict1[iddict[frozenset([3, 5])]]
+    i123 = facedict1[members_to_id[frozenset([1, 2, 3])]]
+    i2345 = tetdict1[members_to_id[frozenset([2, 3, 4, 5])]]
+    i345 = facedict1[members_to_id[frozenset([3, 4, 5])]]
+    i245 = facedict1[members_to_id[frozenset([2, 4, 5])]]
+    i12 = edgedict1[members_to_id[frozenset([1, 2])]]
+    i24 = edgedict1[members_to_id[frozenset([2, 4])]]
+    i34 = edgedict1[members_to_id[frozenset([3, 4])]]
+    i235 = facedict1[members_to_id[frozenset([2, 3, 5])]]
+    i23 = edgedict1[members_to_id[frozenset([2, 3])]]
+    i45 = edgedict1[members_to_id[frozenset([4, 5])]]
+    i234 = facedict1[members_to_id[frozenset([2, 3, 4])]]
+    i25 = edgedict1[members_to_id[frozenset([2, 5])]]
+    i13 = edgedict1[members_to_id[frozenset([1, 3])]]
+    i35 = edgedict1[members_to_id[frozenset([3, 5])]]
 
     assert B1[nodedict1[1], i12] == -1
     assert B1[nodedict1[2], i12] == 1
@@ -546,7 +545,7 @@ def test_boundary_matrix(edgelist4):
     assert np.linalg.norm(B2 @ B3) == 0
 
     # Change the orientation of a face
-    orientations[iddict[frozenset([3, 4, 5])]] = 1
+    orientations[members_to_id[frozenset([3, 4, 5])]] = 1
 
     B1 = xgi.boundary_matrix(S1, order=1, orientations=orientations, index=False)
     B2 = xgi.boundary_matrix(S1, order=2, orientations=orientations, index=False)

--- a/tests/stats/test_nodestats.py
+++ b/tests/stats/test_nodestats.py
@@ -518,7 +518,7 @@ def test_multi_stats_aspandas(edgelist1, edgelist8):
         ["average_neighbor_degree", "degree", H.nodes.degree(order=2)]
     )
     df = pd.DataFrame(multi.asdict(transpose=True))
-    pd.testing.assert_frame_equal(df, multi.aspandas())
+    pd.testing.assert_frame_equal(df, multi.aspandas(), check_like=True)
 
     H = xgi.Hypergraph(edgelist8)
     multi = H.nodes.multi(

--- a/xgi/classes/reportviews.py
+++ b/xgi/classes/reportviews.py
@@ -111,18 +111,15 @@ class IDView(Mapping, Set):
         always use `x in view`.  The latter is always faster.
 
         """
-        return set(self._id_dict) if self._ids is None else self._ids
+        return set(self._ids)
 
     def __len__(self):
         """The number of IDs."""
-        return len(self._id_dict) if self._ids is None else len(self._ids)
+        return len(self._ids)
 
     def __iter__(self):
         """Returns an iterator over the IDs."""
-        if self._ids is None:
-            return iter({}) if self._id_dict is None else iter(self._id_dict)
-        else:
-            return iter(self._ids)
+        return iter(self._ids)
 
     def __getitem__(self, id):
         """Get the attributes of the ID.


### PR DESCRIPTION
Currently, H.edges.ids sometimes returns a dict and sometimes returns a set:

```python3
>>> import xgi
>>> H  = xgi.Hypergraph([{1, 2, 3}, {4}, {5, 6}, {6, 7, 8}])
>>> H.edges.ids
{0: {1, 2, 3}, 1: {4}, 2: {5, 6}, 3: {6, 7, 8}}
>>> H.edges({0, 1, 2}).ids
{0, 1, 2}
```
This is terrible. Furthermore, the dict version can be obtained via members:
```python3
>>> H.edges.members(dtype=dict)
{0: {1, 2, 3}, 1: {4}, 2: {5, 6}, 3: {6, 7, 8}}
```

This PR makes it so that it always returns a set.
```python3
>>> import xgi
>>> H  = xgi.Hypergraph([{1, 2, 3}, {4}, {5, 6}, {6, 7, 8}])
>>> H.edges.ids
{0, 1, 2, 3}
```

I also added a couple of tests and changed an old test that relied on `ids` returning a dict (yuck).