### PR TITLE
Only count the text in the line counts

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,4 @@
 # Auto detect text files and perform LF normalization
 * text=auto
+
+*.ipynb text


### PR DESCRIPTION
This line supposedly fixes the inaccurate line counts in the Jupyter notebooks, e.g., https://github.com/pytorch/vision/issues/2771

If we would rather, we can simply remove the count for Jupyter notebooks altogether.