### PR TITLE
Move `to_line_graph` from `convert.py` and add weight options

### DIFF
--- a/xgi/__init__.py
+++ b/xgi/__init__.py
@@ -16,6 +16,7 @@ from .utils import *
 from .classes import *
 from .algorithms import *
 from .convert import *
+from .line_graphs import *
 from .drawing import *
 from .dynamics import *
 from .generators import *

--- a/xgi/algorithms/centrality.py
+++ b/xgi/algorithms/centrality.py
@@ -8,7 +8,7 @@ from numpy.linalg import norm
 from scipy.sparse.linalg import eigsh
 
 from ..classes import convert_labels_to_integers, is_uniform
-from ..convert import to_line_graph
+from ..line_graphs import to_line_graph
 from ..exception import XGIError
 from ..linalg import clique_motif_matrix, incidence_matrix
 

--- a/xgi/convert.py
+++ b/xgi/convert.py
@@ -39,7 +39,6 @@ __all__ = [
     "from_bipartite_graph",
     "to_bipartite_graph",
     "dict_to_hypergraph",
-    "to_line_graph",
     "from_simplex_dict",
 ]
 
@@ -214,46 +213,6 @@ def convert_to_graph(H):
     G = nx.from_scipy_sparse_array(A)
     G = nx.relabel_nodes(G, {i: node for i, node in enumerate(H.nodes)})
     return G
-
-
-def to_line_graph(H, s=1):
-    """The s-line graph of the hypergraph.
-
-    The line graph of the hypergraph `H` is the graph whose
-    nodes correspond to each hyperedge in `H`, linked together
-    if they share at least one vertex.
-
-    Parameters
-    ----------
-    H : Hypergraph
-        The hypergraph of interest
-    s : int
-        The intersection size to consider edges
-        as connected, by default 1.
-
-    Returns
-    -------
-    LG : networkx.Graph
-         The line graph associated to the Hypergraph
-
-    References
-    ----------
-    "Hypernetwork science via high-order hypergraph walks", by Sinan G. Aksoy, Cliff
-    Joslyn, Carlos Ortiz Marrero, Brenda Praggastis & Emilie Purvine.
-    https://doi.org/10.1140/epjds/s13688-020-00231-0
-
-    """
-    LG = nx.Graph()
-
-    edge_label_dict = {tuple(edge): index for index, edge in H._edge.items()}
-
-    LG.add_nodes_from(H.edges)
-
-    for edge1, edge2 in combinations(H.edges.members(), 2):
-        if len(edge1.intersection(edge2)) >= s:
-            LG.add_edge(edge_label_dict[tuple(edge1)], edge_label_dict[tuple(edge2)])
-
-    return LG
 
 
 def convert_to_simplicial_complex(data, create_using=None):

--- a/xgi/line_graphs.py
+++ b/xgi/line_graphs.py
@@ -1,0 +1,57 @@
+import networkx as nx
+
+__all__ = [
+    "to_line_graph"
+]
+
+
+def to_line_graph(H, s=1, normalize_weights=False):
+    """The s-line graph of the hypergraph.
+
+    The line graph of the hypergraph `H` is the graph whose
+    nodes correspond to each hyperedge in `H`, linked together
+    if they share at least one vertex. Edge weights correspond
+    to the size of the intersection between the hyperedges,
+    optionally normalized by the size of the smaller hyperedge.
+
+    Parameters
+    ----------
+    H : Hypergraph
+        The hypergraph of interest
+    s : int
+        The intersection size to consider edges
+        as connected, by default 1.
+    normalize_weights : bool
+        If True, normalize edge weights by the
+        size of the smaller hyperedge.
+
+    Returns
+    -------
+    LG : networkx.Graph
+         The line graph associated to the Hypergraph
+
+    References
+    ----------
+    "Hypernetwork science via high-order hypergraph walks", by Sinan G. Aksoy, Cliff
+    Joslyn, Carlos Ortiz Marrero, Brenda Praggastis & Emilie Purvine.
+    https://doi.org/10.1140/epjds/s13688-020-00231-0
+
+    """
+    LG = nx.Graph()
+
+    edge_label_dict = {tuple(edge): index for index, edge in H._edge.items()}
+
+    LG.add_nodes_from(H.edges)
+
+    for edge1, edge2 in combinations(H.edges.members(), 2):
+        intersection_size = len(edge1.intersection(edge2))
+        if intersection_size >= s:
+            weight = intersection_size
+            if normalize_weights:
+                weight /= min([len(edge1), len(edge2)])
+
+            LG.add_edge(edge_label_dict[tuple(edge1)],
+                        edge_label_dict[tuple(edge2)],
+                        weight=weight)
+
+    return LG

--- a/xgi/line_graphs.py
+++ b/xgi/line_graphs.py
@@ -7,14 +7,16 @@ __all__ = [
 ]
 
 
-def to_line_graph(H, s=1, normalize_weights=False):
+def to_line_graph(H, s=1, weighted=False, normalize_weights=False):
     """The s-line graph of the hypergraph.
 
-    The line graph of the hypergraph `H` is the graph whose
+    The s-line graph of the hypergraph `H` is the graph whose
     nodes correspond to each hyperedge in `H`, linked together
-    if they share at least one vertex. Edge weights correspond
-    to the size of the intersection between the hyperedges,
-    optionally normalized by the size of the smaller hyperedge.
+    if they share at least s vertices.
+
+    Optional edge weights correspond to the size of the
+    intersection between the hyperedges, optionally
+    normalized by the size of the smaller hyperedge.
 
     Parameters
     ----------
@@ -23,9 +25,13 @@ def to_line_graph(H, s=1, normalize_weights=False):
     s : int
         The intersection size to consider edges
         as connected, by default 1.
+    weighted : bool
+        If True, include edge weights corresponding
+        to the size of intersection between hyperedges.
     normalize_weights : bool
         If True, normalize edge weights by the
-        size of the smaller hyperedge.
+        size of the smaller hyperedge. Has no effect
+        if weighted=False.
 
     Returns
     -------
@@ -46,13 +52,20 @@ def to_line_graph(H, s=1, normalize_weights=False):
     LG.add_nodes_from(H.edges)
 
     for edge1, edge2 in combinations(H.edges.members(), 2):
+        # Check that the intersection size is larger than s
         intersection_size = len(edge1.intersection(edge2))
         if intersection_size >= s:
-            weight = intersection_size
-            if normalize_weights:
-                weight /= min([len(edge1), len(edge2)])
-
-            LG.add_edge(edge_label_dict[tuple(edge1)],
+            if not weighted:
+                # Add unweighted edge
+                LG.add_edge(edge_label_dict[tuple(edge1)],
+                            edge_label_dict[tuple(edge2)])
+            else:
+                # Compute the (normalized) weight
+                weight = intersection_size
+                if normalize_weights:
+                    weight /= min([len(edge1), len(edge2)])
+                # Add edge with weight
+                LG.add_edge(edge_label_dict[tuple(edge1)],
                         edge_label_dict[tuple(edge2)],
                         weight=weight)
 

--- a/xgi/line_graphs.py
+++ b/xgi/line_graphs.py
@@ -1,3 +1,5 @@
+from itertools import combinations
+
 import networkx as nx
 
 __all__ = [


### PR DESCRIPTION
First in a series of PRs relating to #413. It does 2 main things:

1. Moves `to_line_graph` from `convert.py` into a new file called `line_graphs.py`, modifies files that refer to `convert.to_line_graph`, and adds `.line_graphs` to `__init__.py`
3. Adds `weighted` and `normalize_weight` options to `to_line_graph`

I decided to keep the default behavior as returning an unweighted line graph for now. So when `weighted=False`, the function behaves exactly the same as before (and `normalize_weights` has no effect). If `weighted=True`, the returned graph also has a `weight` attribute corresponding to the size of the intersection between the hyperedges. This adds no further computation, since the interesection size is needed anyway, but adds an integer attribute to every edge. If `weighted=True` and `normalize_weights=True`, the `weight` attribute is normalized by the minimum size between the two hyperedges (meaning it is a float between 0.0 and 1.0).

Instead of the two boolean options, we could either:
1. Return absolute weights by default. In this case we wouldn't need `weighted`, just `normalize_weights`.
2. Use a string input for normalization, something like `weight_type` with defualt `'unweighted'` and other options `'absolute'` and `'normalized'`.

Will also need to check again that everything works once #423 is merged.