### PR TITLE
Changed rho to an optional arg in `uniform_HPPM` function

### DIFF
--- a/tests/generators/test_uniform.py
+++ b/tests/generators/test_uniform.py
@@ -93,7 +93,7 @@ def test_uniform_HPPM():
         rho = -0.1
         k = 2
         epsilon = 0.5
-        xgi.uniform_HPPM(n, m, rho, k, epsilon)
+        xgi.uniform_HPPM(n, m, k, epsilon, rho)
 
     # rho > 1
     with pytest.raises(XGIError):
@@ -102,7 +102,7 @@ def test_uniform_HPPM():
         rho = 1.1
         k = 2
         epsilon = 0.5
-        xgi.uniform_HPPM(n, m, rho, k, epsilon)
+        xgi.uniform_HPPM(n, m, k, epsilon, rho)
 
     # k < 0
     with pytest.raises(XGIError):
@@ -111,7 +111,7 @@ def test_uniform_HPPM():
         rho = 0.5
         k = -2
         epsilon = 0.5
-        xgi.uniform_HPPM(n, m, rho, k, epsilon)
+        xgi.uniform_HPPM(n, m, k, epsilon, rho)
 
     # epsilon < 0
     with pytest.raises(XGIError):
@@ -120,7 +120,7 @@ def test_uniform_HPPM():
         rho = 0.5
         k = 2
         epsilon = -0.1
-        xgi.uniform_HPPM(n, m, rho, k, epsilon)
+        xgi.uniform_HPPM(n, m, k, epsilon)
 
     # epsilon < 0
     with pytest.raises(XGIError):
@@ -129,20 +129,20 @@ def test_uniform_HPPM():
         rho = 0.5
         k = 2
         epsilon = 1.1
-        xgi.uniform_HPPM(n, m, rho, k, epsilon)
+        xgi.uniform_HPPM(n, m, k, epsilon)
 
     m = 2
     n = 10
     rho = 0.5
     k = 2
     epsilon = 0.8
-    H1 = xgi.uniform_HPPM(n, m, rho, k, epsilon, seed=0)
+    H1 = xgi.uniform_HPPM(n, m, k, epsilon, seed=0)
 
     assert H1.num_nodes == 10
     assert xgi.unique_edge_sizes(H1) == [2]
 
     # test that the seed works
-    H2 = xgi.uniform_HPPM(n, m, rho, k, epsilon, seed=0)
+    H2 = xgi.uniform_HPPM(n, m, k, epsilon, rho, seed=0)
 
     assert H1.edges.members(dtype=dict) == H2.edges.members(dtype=dict)
 

--- a/xgi/generators/uniform.py
+++ b/xgi/generators/uniform.py
@@ -195,7 +195,7 @@ def uniform_HSBM(n, m, p, sizes, seed=None):
     return H
 
 
-def uniform_HPPM(n, m, rho, k, epsilon, seed=None):
+def uniform_HPPM(n, m, k, epsilon, rho=0.5, seed=None):
     """Construct the m-uniform hypergraph planted partition model (m-HPPM)
 
     Parameters
@@ -204,12 +204,12 @@ def uniform_HPPM(n, m, rho, k, epsilon, seed=None):
         Number of nodes
     m : int > 0
         Hyperedge size
-    rho : float between 0 and 1
-        The fraction of nodes in community 1
     k : float > 0
         Mean degree
     epsilon : float > 0
         Imbalance parameter
+    rho : float between 0 and 1, optional
+        The fraction of nodes in community 1, default 0.5
     seed : integer or None (default)
         The seed for the random number generator
 


### PR DESCRIPTION
The most natural value of rho is 0.5 (two equally sized communities), so this PR will make this as the default value.