### PR TITLE
Fix #461

### DIFF
--- a/tests/core/test_hypergraph.py
+++ b/tests/core/test_hypergraph.py
@@ -72,7 +72,9 @@ def test_lshift(edgelist1, edgelist2, hyperwithattrs):
     H2 = xgi.Hypergraph(edgelist2)
     H3 = hyperwithattrs
     H = H1 << H2
-    assert set(H.nodes) == {1, 2, 3, 4, 5, 6, 7, 8}
+    nodes1 = list(H1.nodes)
+    assert nodes1 == [1, 2, 3, 4, 5, 6, 8, 7]
+    assert list(H.nodes) == nodes1
     assert H.num_edges == 7
     assert H.edges.members(0) == {1, 2, 3}
 

--- a/xgi/core/hypergraph.py
+++ b/xgi/core/hypergraph.py
@@ -273,11 +273,12 @@ class Hypergraph:
         [{1, 2}, {2, 3}, {1, 3, 4}]
         """
         tempH = Hypergraph()
-        tempH.add_edges_from(zip(self._edge.values(), self._edge_attr.values()))
-        tempH.add_nodes_from(zip(self._node.keys(), self._node_attr.values()))
 
-        tempH.add_edges_from(zip(H2._edge.values(), H2._edge_attr.values()))
+        tempH.add_nodes_from(zip(self._node.keys(), self._node_attr.values()))
         tempH.add_nodes_from(zip(H2._node.keys(), H2._node_attr.values()))
+
+        tempH.add_edges_from(zip(self._edge.values(), self._edge_attr.values()))
+        tempH.add_edges_from(zip(H2._edge.values(), H2._edge_attr.values()))
 
         tempH._hypergraph = deepcopy(self._hypergraph)
         tempH._hypergraph.update(deepcopy(H2._hypergraph))


### PR DESCRIPTION
Keep a consistent node order with lshift, solving #461.