### PR TITLE
Make IDViews respect order

### DIFF
--- a/tests/core/test_diviews.py
+++ b/tests/core/test_diviews.py
@@ -191,7 +191,7 @@ def test_view_len(diedgelist2):
 
 def test_bunch_view(diedgelist2):
     H = xgi.DiHypergraph(diedgelist2)
-    bunch_view = H.edges.from_view(H.edges, bunch=[1, 2])
+    bunch_view = H.edges.from_view(H.edges, bunch=[2, 1])
     assert len(bunch_view) == 2
     assert (1 in bunch_view) and (2 in bunch_view)
     assert 0 not in bunch_view

--- a/tests/core/test_diviews.py
+++ b/tests/core/test_diviews.py
@@ -198,6 +198,8 @@ def test_bunch_view(diedgelist2):
     assert bunch_view.members(dtype=dict) == {1: {1, 2, 4}, 2: {2, 3, 4, 5}}
     with pytest.raises(IDNotFound):
         bunch_view.members(0)
+    # test ID order
+    assert list(bunch_view) == [1, 2]
 
 
 def test_call_wrong_bunch():

--- a/tests/core/test_views.py
+++ b/tests/core/test_views.py
@@ -210,7 +210,7 @@ def test_view_len(edgelist2):
 
 def test_bunch_view(edgelist1):
     H = xgi.Hypergraph(edgelist1)
-    bunch_view = H.edges.from_view(H.edges, bunch=[1, 2])
+    bunch_view = H.edges.from_view(H.edges, bunch=[2, 1])
     assert len(bunch_view) == 2
     assert (1 in bunch_view) and (2 in bunch_view)
     assert 0 not in bunch_view

--- a/tests/core/test_views.py
+++ b/tests/core/test_views.py
@@ -218,6 +218,8 @@ def test_bunch_view(edgelist1):
     with pytest.raises(IDNotFound):
         bunch_view.members(0)
 
+    assert list(bunch_view) == [1, 2]
+
 
 def test_call_wrong_bunch():
     H = xgi.Hypergraph()

--- a/xgi/core/diviews.py
+++ b/xgi/core/diviews.py
@@ -365,7 +365,7 @@ class DiIDView(Mapping, Set):
             wrong = bunch - all_ids
             if wrong:
                 raise IDNotFound(f"IDs {wrong} not in the hypergraph")
-            newview._ids = bunch
+            newview._ids = [i for i in view._id_dict if i in bunch]
         return newview
 
     def _from_iterable(self, it):

--- a/xgi/core/diviews.py
+++ b/xgi/core/diviews.py
@@ -365,7 +365,7 @@ class DiIDView(Mapping, Set):
             wrong = bunch - all_ids
             if wrong:
                 raise IDNotFound(f"IDs {wrong} not in the hypergraph")
-            newview._ids = [i for i in view._id_dict if i in bunch]
+            newview._ids = [i for i in view._in_id_dict if i in bunch]
         return newview
 
     def _from_iterable(self, it):

--- a/xgi/core/views.py
+++ b/xgi/core/views.py
@@ -511,7 +511,7 @@ class IDView(Mapping, Set):
             wrong = bunch - all_ids
             if wrong:
                 raise IDNotFound(f"IDs {wrong} not in the hypergraph")
-            newview._ids = bunch
+            newview._ids = [i for i in view._id_dict if i in bunch]
         return newview
 
     def _from_iterable(self, it):


### PR DESCRIPTION
Before, the ids in the IDView could be unordered. This respects the insertion order of the edges.