### PR TITLE
change xgi-data index location

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ To get started, take a look at the [tutorials](https://xgi.readthedocs.io/en/sta
 
 
 ## Corresponding Data
-A number of higher-order datasets are available in the [XGI-DATA repository](https://gitlab.com/complexgroupinteractions/xgi-data) and can be easily accessed with the `load_xgi_data()` function.
+A number of higher-order datasets are available in the [XGI-DATA repository](https://github.com/xgi-org/xgi-data) and can be easily accessed with the `load_xgi_data()` function.
 
 
 ## How to Contribute

--- a/docs/source/api/tutorials/XGI in 15 minutes.ipynb
+++ b/docs/source/api/tutorials/XGI in 15 minutes.ipynb
@@ -28,7 +28,7 @@
    "source": [
     "## Uploading a dataset\n",
     "\n",
-    "In this tutorial we will construct a hypergraph describing real world data! With XGI we provide a companion data repository, [xgi-data](https://gitlab.com/complexgroupinteractions/xgi-data), with which you can easely load several datasets in standard format:"
+    "In this tutorial we will construct a hypergraph describing real world data! With XGI we provide a companion data repository, [xgi-data](https://github.com/xgi-org/xgi-data), with which you can easely load several datasets in standard format:"
    ]
   },
   {

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -106,7 +106,7 @@ XGI was developed and tested for Python 3.8-3.12 on Mac OS, Windows, and Ubuntu.
 Corresponding Data
 ==================
 
-A number of higher-order datasets are available in the `XGI-DATA repository <https://gitlab.com/complexgroupinteractions/xgi-data>`_ and can be easily accessed with the ``load_xgi_data()`` function.
+A number of higher-order datasets are available in the `XGI-DATA repository <https://github.com/xgi-org/xgi-data>`_ and can be easily accessed with the ``load_xgi_data()`` function.
 
 
 Contributing

--- a/long_description.rst
+++ b/long_description.rst
@@ -35,7 +35,7 @@ illustrating the library's basic functionality.
 
 Corresponding Data
 ------------------
-A number of higher-order datasets are available in the `XGI-DATA repository <https://gitlab.com/complexgroupinteractions/xgi-data>`_ and can be easily accessed with the ``load_xgi_data()`` function.
+A number of higher-order datasets are available in the `XGI-DATA repository <https://github.com/xgi-org/xgi-data>`_ and can be easily accessed with the ``load_xgi_data()`` function.
 
 Contributing
 ------------

--- a/xgi/readwrite/xgi_data.py
+++ b/xgi/readwrite/xgi_data.py
@@ -52,14 +52,10 @@ def load_xgi_data(
     XGIError
        The specified dataset does not exist.
     """
-    index_url = (
-        "https://gitlab.com/complexgroupinteractions/"
-        "xgi-data/-/raw/main/index.json?inline=false"
-    )
+    index_url = "https://raw.githubusercontent.com/xgi-org/xgi-data/main/index.json"
 
     # If no dataset is specified, print a list of the available datasets.
     if dataset is None:
-
         index_data = request_json_from_url(index_url)
         print("Available datasets are the following:")
         print(*index_data, sep="\n")
@@ -79,7 +75,7 @@ def load_xgi_data(
                 "from the xgi-data repository instead. To download a local "
                 "copy, use `download_xgi_data`."
             )
-    data = _request_from_xgi_data(dataset, cache=cache)
+    data = _request_from_xgi_data(index_url, dataset, cache=cache)
 
     return convert.dict_to_hypergraph(
         data, nodetype=nodetype, edgetype=edgetype, max_order=max_order
@@ -99,14 +95,14 @@ def download_xgi_data(dataset, path=""):
         Path to where the local copy should be saved. If none is given, save
         file to local directory.
     """
-
-    jsondata = _request_from_xgi_data(dataset)
+    index_url = "https://raw.githubusercontent.com/xgi-org/xgi-data/main/index.json"
+    jsondata = _request_from_xgi_data(index_url, dataset)
     jsonfile = open(os.path.join(path, dataset + ".json"), "w")
     json.dump(jsondata, jsonfile)
     jsonfile.close()
 
 
-def _request_from_xgi_data(dataset=None, cache=True):
+def _request_from_xgi_data(index_url, dataset=None, cache=True):
     """Request a dataset from xgi-data.
 
     Parameters
@@ -132,11 +128,6 @@ def _request_from_xgi_data(dataset=None, cache=True):
     ---------
     load_xgi_data
     """
-    index_url = (
-        "https://gitlab.com/complexgroupinteractions/"
-        "xgi-data/-/raw/main/index.json?inline=false"
-    )
-
     index_data = request_json_from_url(index_url)
 
     key = dataset.lower()


### PR DESCRIPTION
This PR accompanies [this](https://github.com/xgi-org/xgi-data/pull/16) XGI-DATA PR and changes the location of the index file. Once that PR is merged, this one can be too. For now, I think we can leave the xgi-data repository at GitLab open, but the landing page should redirect to the Github page.