### PR TITLE
Made exact assortativity reproducible

### DIFF
--- a/tests/algorithms/test_assortativity.py
+++ b/tests/algorithms/test_assortativity.py
@@ -49,6 +49,19 @@ def test_degree_assortativity(edgelist1, edgelist5):
     assert -1 <= xgi.degree_assortativity(H1, kind="top-2", exact=True) <= 1
     assert -1 <= xgi.degree_assortativity(H1, kind="top-bottom", exact=True) <= 1
 
+    # check that exact returns the same
+    rho1 = xgi.degree_assortativity(H1, kind="uniform", exact=True)
+    rho2 = xgi.degree_assortativity(H1, kind="uniform", exact=True)
+    assert rho1 == rho2
+
+    rho1 = xgi.degree_assortativity(H1, kind="top-2", exact=True)
+    rho2 = xgi.degree_assortativity(H1, kind="top-2", exact=True)
+    assert rho1 == rho2
+
+    rho1 = xgi.degree_assortativity(H1, kind="top-bottom", exact=True)
+    rho2 = xgi.degree_assortativity(H1, kind="top-bottom", exact=True)
+    assert rho1 == rho2
+
     # test empty
     H = xgi.Hypergraph()
     with pytest.raises(XGIError):


### PR DESCRIPTION
In the `degree_assortativity` function, when using the `exact` keyword, it was not reproducible because the two degrees were randomly shuffled prior to putting into the `numpy.corrcoef` function. NetworkX handles this by copying the pairs twice: $(u, v)$ and $(v,u )$ (See this [comment](https://github.com/networkx/networkx/blob/f44fdc4d12cd36907959637961865a0325383a91/networkx/algorithms/assortativity/pairs.py#L38)). This PR fixes this issue.