### PR TITLE
feat: format XGI-DATA numbers

### DIFF
--- a/docs/source/_static/table.js
+++ b/docs/source/_static/table.js
@@ -46,7 +46,7 @@ async function fetch_JSON_file(url) {
             const td = document.createElement('td');
             const attr = header_attrs[i]
             if (json_data[key][attr]) {
-                td.textContent = json_data[key][attr];
+                td.textContent = json_data[key][attr].toLocaleString();
             }
             else {
                 td.textContent = "N/A"


### PR DESCRIPTION
Due to an upstream change in XGI-DATA (xgi-org/xgi-data#23), the [XGI-DATA page](https://xgi.readthedocs.io/en/stable/xgi-data.html) now shows numbers without comma separators.

This PR adds the commas back.