### PR TITLE
Warn on unknown type of degree assortativity

### DIFF
--- a/tests/algorithms/test_assortativity.py
+++ b/tests/algorithms/test_assortativity.py
@@ -71,6 +71,12 @@ def test_degree_assortativity(edgelist1, edgelist5):
     with pytest.raises(XGIError):
         xgi.degree_assortativity(H)
 
+    # test wrong kind
+    with pytest.raises(XGIError):
+        xgi.degree_assortativity(H1, kind="no-idea")
+    with pytest.raises(XGIError):
+        xgi.degree_assortativity(H1, kind="no-idea", exact=True)
+
 
 def test_choose_degrees(edgelist1, edgelist6):
     H1 = xgi.Hypergraph(edgelist1)

--- a/xgi/algorithms/assortativity.py
+++ b/xgi/algorithms/assortativity.py
@@ -136,6 +136,8 @@ def degree_assortativity(H, kind="uniform", exact=False, num_samples=1000):
                 for d in permutations(_choose_degrees(members[e], k, "top-bottom"), 2)
                 # permutations is so that k1 and k2 have the same variance
             ]
+        else:
+            raise XGIError("Invalid type of degree assortativity!")
     else:
         edges = [e for e in H.edges if len(H.edges.members(e)) > 1]
         k1k2 = [
@@ -202,6 +204,6 @@ def _choose_degrees(e, k, kind="uniform"):
             return sorted([k[i] for i in e])[:: len(e) - 1]
 
         else:
-            raise XGIError("Invalid choice function!")
+            raise XGIError("Invalid type of degree assortativity!")
     else:
         raise XGIError("Edge must have more than one member!")


### PR DESCRIPTION
When calling `xgi.degree_assortativity()` with `exact=True` and an unknown `kind`, the code raises an `UnboundLocalError` that is hard to debug.
This PR fixes that behavior.

Unknown `kind`-s are handled in `_choose_degrees`, but after #526, when `exact=True`,  `_choose_degrees` is no longer called.

I also changed the message from
> Invalid choice function!

to

> Invalid type of degree assortativity!

to better describe the error.

(I found this because I made a typo in `kind=`.)