### PR TITLE
Fix scipy error

### DIFF
--- a/HOW_TO_CONTRIBUTE.md
+++ b/HOW_TO_CONTRIBUTE.md
@@ -11,8 +11,8 @@ Please note we have a [code of conduct](/CODE_OF_CONDUCT.md), please follow it i
 3. Include any new method/function in the corresponding docs file.
 4. Run `pytest` to verify all unit tests pass.
 5. Identify the unnecessary imports in the
-   1. source code by running `pylint xgi/ --disable all --enable W0611`
-   2. notebooks by running `nbqa pylint . --disable all --enable W0611`
+   1. source code by running `pylint xgi/ --disable=all --enable W0611`
+   2. notebooks by running `nbqa pylint . --disable=all --enable W0611`
 6. Remove these unnecessary imports.
 7. Sort the import statements in the
    1. source code by running `isort .`

--- a/benchmarks/networkx.ipynb
+++ b/benchmarks/networkx.ipynb
@@ -15,8 +15,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "import time\n",
-    "\n",
     "import networkx as nx\n",
     "\n",
     "import xgi"

--- a/requirements/developer.txt
+++ b/requirements/developer.txt
@@ -1,5 +1,5 @@
 black[jupyter]>=24.3
 pre-commit>=2.12
 isort==5.10.1
-pylint>=2.10
+pylint>=3.0
 nbqa

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -223,7 +223,7 @@ def hypergraph2():
 def simplicialcomplex1():
     S = xgi.SimplicialComplex()
     S.add_nodes_from(["b", "c", 0])
-    S.add_edges_from(
+    S.add_simplices_from(
         {"e1": [0, "b"], "e2": [0, "c"], "e3": [0, "b", "c"], "e4": ["b", "c"]}
     )
     return S

--- a/xgi/algorithms/centrality.py
+++ b/xgi/algorithms/centrality.py
@@ -58,7 +58,10 @@ def clique_eigenvector_centrality(H, tol=1e-6):
     if not is_connected(H):
         return {n: np.nan for n in H.nodes}
     W, node_dict = clique_motif_matrix(H, index=True)
-    _, v = eigsh(W.asfptype(), k=1, which="LM", tol=tol)
+    try:
+        _, v = eigsh(W.astype(float), k=1, which="LM", tol=tol)
+    except AttributeError:
+        _, v = eigsh(W.asfptype(), k=1, which="LM", tol=tol)
 
     # multiply by the sign to try and enforce positivity
     v = np.sign(v[0]) * v / norm(v, 1)

--- a/xgi/algorithms/centrality.py
+++ b/xgi/algorithms/centrality.py
@@ -58,10 +58,7 @@ def clique_eigenvector_centrality(H, tol=1e-6):
     if not is_connected(H):
         return {n: np.nan for n in H.nodes}
     W, node_dict = clique_motif_matrix(H, index=True)
-    try:
-        _, v = eigsh(W.astype(float), k=1, which="LM", tol=tol)
-    except AttributeError:
-        _, v = eigsh(W.asfptype(), k=1, which="LM", tol=tol)
+    _, v = eigsh(W.astype(float), k=1, which="LM", tol=tol)
 
     # multiply by the sign to try and enforce positivity
     v = np.sign(v[0]) * v / norm(v, 1)


### PR DESCRIPTION
This fixes an error with the Scipy up-version related to `asfptype()`. In addition, it does the following:
* up-versions pylint
* Removes an unnecessary import
* Removes a warning in the unit tests