### PR TITLE
Rename `_hypergraph` to `_net_attr`

### DIFF
--- a/tests/convert/test_hypergraph_dict.py
+++ b/tests/convert/test_hypergraph_dict.py
@@ -115,7 +115,7 @@ def test_from_hypergraph_dict(edgelist1):
     for n in H.nodes:
         assert H.nodes[n] == Hd.nodes[n]
 
-    assert H._hypergraph == Hd._hypergraph
+    assert H._net_attr == Hd._net_attr
 
     # test bad dicts
     hd = {

--- a/tests/core/test_dihypergraph.py
+++ b/tests/core/test_dihypergraph.py
@@ -26,7 +26,7 @@ def test_constructor(diedgelist1, diedgedict1):
 
 def test_hypergraph_attrs():
     H = xgi.DiHypergraph()
-    assert H._hypergraph == {}
+    assert H._net_attr == {}
     with pytest.raises(XGIError):
         H["name"]
     H = xgi.DiHypergraph(name="test")
@@ -347,7 +347,7 @@ def test_copy(diedgelist1):
     assert list(copy.nodes) == list(H.nodes)
     assert list(copy.edges) == list(H.edges)
     assert list(copy.edges.members()) == list(H.edges.members())
-    assert H._hypergraph == copy._hypergraph
+    assert H._net_attr == copy._net_attr
 
     H.add_node(10)
     assert list(copy.nodes) != list(H.nodes)
@@ -357,7 +357,7 @@ def test_copy(diedgelist1):
     assert list(copy.edges) != list(H.edges)
 
     H["key2"] = "value2"
-    assert H._hypergraph != copy._hypergraph
+    assert H._net_attr != copy._net_attr
 
     copy.add_node(10)
     copy.add_edge(([1, 3, 5], [6]))
@@ -365,7 +365,7 @@ def test_copy(diedgelist1):
     assert list(copy.nodes) == list(H.nodes)
     assert list(copy.edges) == list(H.edges)
     assert list(copy.edges.members()) == list(H.edges.members())
-    assert H._hypergraph == copy._hypergraph
+    assert H._net_attr == copy._net_attr
 
     H1 = xgi.DiHypergraph()
     H1.add_edge(([1, 2], [3]), id="x")
@@ -373,7 +373,7 @@ def test_copy(diedgelist1):
     assert list(copy2.nodes) == list(H1.nodes)
     assert list(copy2.edges) == list(H1.edges)
     assert list(copy2.edges.members()) == list(H1.edges.members())
-    assert H1._hypergraph == copy2._hypergraph
+    assert H1._net_attr == copy2._net_attr
 
 
 def test_copy_issue128():

--- a/tests/core/test_hypergraph.py
+++ b/tests/core/test_hypergraph.py
@@ -49,7 +49,7 @@ def test_constructor(edgelist5, dict5, incidence5, dataframe5):
 
 def test_hypergraph_attrs():
     H = xgi.Hypergraph()
-    assert H._hypergraph == {}
+    assert H._net_attr == {}
     with pytest.raises(XGIError):
         H["name"]
     H = xgi.Hypergraph(name="test")
@@ -414,7 +414,7 @@ def test_copy(edgelist1):
     assert list(copy.nodes) == list(H.nodes)
     assert list(copy.edges) == list(H.edges)
     assert list(copy.edges.members()) == list(H.edges.members())
-    assert H._hypergraph == copy._hypergraph
+    assert H._net_attr == copy._net_attr
 
     H.add_node(10)
     assert list(copy.nodes) != list(H.nodes)
@@ -424,7 +424,7 @@ def test_copy(edgelist1):
     assert list(copy.edges) != list(H.edges)
 
     H["key2"] = "value2"
-    assert H._hypergraph != copy._hypergraph
+    assert H._net_attr != copy._net_attr
 
     copy.add_node(10)
     copy.add_edge([1, 3, 5])
@@ -432,7 +432,7 @@ def test_copy(edgelist1):
     assert list(copy.nodes) == list(H.nodes)
     assert list(copy.edges) == list(H.edges)
     assert list(copy.edges.members()) == list(H.edges.members())
-    assert H._hypergraph == copy._hypergraph
+    assert H._net_attr == copy._net_attr
 
     H1 = xgi.Hypergraph()
     H1.add_edge((1, 2), id="x")
@@ -440,7 +440,7 @@ def test_copy(edgelist1):
     assert list(copy2.nodes) == list(H1.nodes)
     assert list(copy2.edges) == list(H1.edges)
     assert list(copy2.edges.members()) == list(H1.edges.members())
-    assert H1._hypergraph == copy2._hypergraph
+    assert H1._net_attr == copy2._net_attr
 
 
 def test_copy_issue128():

--- a/tests/core/test_simplicialcomplex.py
+++ b/tests/core/test_simplicialcomplex.py
@@ -389,7 +389,7 @@ def test_copy(edgelist1):
     assert list(copy.nodes) == list(H.nodes)
     assert list(copy.edges) == list(H.edges)
     assert list(copy.edges.members()) == list(H.edges.members())
-    assert H._hypergraph == copy._hypergraph
+    assert H._net_attr == copy._net_attr
 
     H.add_node(10)
     assert list(copy.nodes) != list(H.nodes)
@@ -399,7 +399,7 @@ def test_copy(edgelist1):
     assert list(copy.edges) != list(H.edges)
 
     H["key2"] = "value2"
-    assert H._hypergraph != copy._hypergraph
+    assert H._net_attr != copy._net_attr
 
     copy.add_node(10)
     copy.add_simplex([1, 3, 5])
@@ -407,7 +407,7 @@ def test_copy(edgelist1):
     assert list(copy.nodes) == list(H.nodes)
     assert list(copy.edges) == list(H.edges)
     assert list(copy.edges.members()) == list(H.edges.members())
-    assert H._hypergraph == copy._hypergraph
+    assert H._net_attr == copy._net_attr
 
     H1 = xgi.SimplicialComplex()
     H1.add_simplex((1, 2), id="x")
@@ -415,7 +415,7 @@ def test_copy(edgelist1):
     assert list(copy2.nodes) == list(H1.nodes)
     assert list(copy2.edges) == list(H1.edges)
     assert list(copy2.edges.members()) == list(H1.edges.members())
-    assert H1._hypergraph == copy2._hypergraph
+    assert H1._net_attr == copy2._net_attr
 
 
 def test_duplicate_edges(edgelist1):

--- a/tests/readwrite/test_json.py
+++ b/tests/readwrite/test_json.py
@@ -1,7 +1,7 @@
 import tempfile
+from os.path import join
 
 import pytest
-from os.path import join
 
 import xgi
 from xgi.exception import XGIError

--- a/xgi/convert/higher_order_network.py
+++ b/xgi/convert/higher_order_network.py
@@ -69,7 +69,7 @@ def to_hypergraph(data, create_using=None):
         H.add_nodes_from((n, attr) for n, attr in data.nodes.items())
         ee = data.edges
         H.add_edges_from((ee.members(e), e, deepcopy(attr)) for e, attr in ee.items())
-        H._hypergraph = deepcopy(data._hypergraph)
+        H._net_attr = deepcopy(data._net_attr)
         return H
 
     elif isinstance(data, DiHypergraph):
@@ -77,7 +77,7 @@ def to_hypergraph(data, create_using=None):
         H.add_nodes_from((n, attr) for n, attr in data.nodes.items())
         ee = data.edges
         H.add_edges_from((ee.members(e), e, deepcopy(attr)) for e, attr in ee.items())
-        H._hypergraph = deepcopy(data._hypergraph)
+        H._net_attr = deepcopy(data._net_attr)
         if not isinstance(create_using, DiHypergraph):
             return H
 
@@ -86,7 +86,7 @@ def to_hypergraph(data, create_using=None):
         H.add_nodes_from((n, attr) for n, attr in data.nodes.items())
         ee = data.edges
         H.add_edges_from((ee.members(e), e, deepcopy(attr)) for e, attr in ee.items())
-        H._hypergraph = deepcopy(data._hypergraph)
+        H._net_attr = deepcopy(data._net_attr)
         return H
 
     elif isinstance(data, list):
@@ -161,7 +161,7 @@ def to_dihypergraph(data, create_using=None):
         H.add_nodes_from((n, attr) for n, attr in data.nodes.items())
         ee = data.edges
         H.add_edges_from((ee.dimembers(e), e, deepcopy(attr)) for e, attr in ee.items())
-        H._hypergraph = deepcopy(data._hypergraph)
+        H._net_attr = deepcopy(data._net_attr)
         if not isinstance(create_using, DiHypergraph):
             return H
 
@@ -222,7 +222,7 @@ def to_simplicial_complex(data, create_using=None):
         H.add_simplices_from(
             (ee.members(e), e, deepcopy(attr)) for e, attr in ee.items()
         )
-        H._hypergraph = deepcopy(data._hypergraph)
+        H._net_attr = deepcopy(data._net_attr)
         return H
 
     elif isinstance(data, Hypergraph):

--- a/xgi/convert/hypergraph_dict.py
+++ b/xgi/convert/hypergraph_dict.py
@@ -33,7 +33,7 @@ def to_hypergraph_dict(H):
     data["type"] = get_network_type(H)
     # name always gets written (default is an empty string)
     data["hypergraph-data"] = {}
-    data["hypergraph-data"].update(H._hypergraph)
+    data["hypergraph-data"].update(H._net_attr)
 
     # get node data
     data["node-data"] = {str(idx): H.nodes[idx] for idx in H.nodes}
@@ -99,7 +99,7 @@ def from_hypergraph_dict(data, nodetype=None, edgetype=None, max_order=None):
     """
     H = empty_hypergraph()
     try:
-        H._hypergraph.update(data["hypergraph-data"])
+        H._net_attr.update(data["hypergraph-data"])
     except KeyError:
         raise XGIError("Failed to get hypergraph data attributes.")
 

--- a/xgi/core/globalviews.py
+++ b/xgi/core/globalviews.py
@@ -56,7 +56,7 @@ def subhypergraph(H, nodes=None, edges=None, keep_isolates=True):
     """
     new = H.__class__()
 
-    new._hypergraph = H._hypergraph.copy()
+    new._net_attr = H._net_attr.copy()
     nodes = set(H.nodes) if nodes is None else (set(nodes) & set(H.nodes))
     edges = set(H.edges) if edges is None else (set(edges) & set(H.edges))
 

--- a/xgi/core/simplicialcomplex.py
+++ b/xgi/core/simplicialcomplex.py
@@ -80,11 +80,11 @@ class SimplicialComplex(Hypergraph):
 
     def __init__(self, incoming_data=None, **attr):
         self._edge_uid = count()
-        self._hypergraph = self._hypergraph_attr_dict_factory()
+        self._net_attr = self._net_attr_dict_factory()
         self._node = self._node_dict_factory()
         self._node_attr = self._node_attr_dict_factory()
-        self._edge = self._hyperedge_dict_factory()
-        self._edge_attr = self._hyperedge_attr_dict_factory()
+        self._edge = self._edge_dict_factory()
+        self._edge_attr = self._edge_attr_dict_factory()
 
         self._nodeview = NodeView(self)
         self._edgeview = EdgeView(self)
@@ -93,7 +93,7 @@ class SimplicialComplex(Hypergraph):
             from ..convert import to_simplicial_complex
 
             to_simplicial_complex(incoming_data, create_using=self)
-        self._hypergraph.update(attr)  # must be after convert
+        self._net_attr.update(attr)  # must be after convert
 
     def __str__(self):
         """Returns a short summary of the simplicial complex.
@@ -232,7 +232,7 @@ class SimplicialComplex(Hypergraph):
             self._node[node].add(id)
 
         self._edge[id] = members
-        self._edge_attr[id] = self._hyperedge_attr_dict_factory()
+        self._edge_attr[id] = self._edge_attr_dict_factory()
         self._edge_attr[id].update(attr)
 
     def _add_face(self, members):
@@ -248,7 +248,7 @@ class SimplicialComplex(Hypergraph):
                 self._node_attr[n] = self._node_attr_dict_factory()
             self._node[n].add(id)
 
-        self._edge_attr[id] = self._hyperedge_attr_dict_factory()
+        self._edge_attr[id] = self._edge_attr_dict_factory()
 
     def add_simplex(self, members, id=None, **attr):
         """Add a simplex to the simplicial complex, and all its subfaces that do
@@ -621,7 +621,7 @@ class SimplicialComplex(Hypergraph):
                     self._node_attr[n] = self._node_attr_dict_factory()
                 self._node[n].add(id)
 
-            self._edge_attr[id] = self._hyperedge_attr_dict_factory()
+            self._edge_attr[id] = self._edge_attr_dict_factory()
             self._edge_attr[id].update(attr)
             self._edge_attr[id].update(eattr)
 
@@ -831,7 +831,7 @@ class SimplicialComplex(Hypergraph):
             (e, id, deepcopy(self.edges[id]))
             for id, e in ee.members(dtype=dict).items()
         )
-        cp._hypergraph = deepcopy(self._hypergraph)
+        cp._net_attr = deepcopy(self._net_attr)
 
         cp._edge_uid = copy(self._edge_uid)
 
@@ -859,7 +859,7 @@ class SimplicialComplex(Hypergraph):
                     (e, id, deepcopy(temp.edges[id]))
                     for id, e in ee.members(dtype=dict).items()
                 )
-                self._hypergraph = deepcopy(temp._hypergraph)
+                self._net_attr = deepcopy(temp._net_attr)
         else:
             S = self.copy()
             if not isolates:

--- a/xgi/generators/random.py
+++ b/xgi/generators/random.py
@@ -1,4 +1,5 @@
 """Generate random (non-uniform) hypergraphs."""
+
 import math
 import random
 import warnings

--- a/xgi/generators/simple.py
+++ b/xgi/generators/simple.py
@@ -4,6 +4,7 @@ All the functions in this module return a Hypergraph class (i.e. a simple, undir
 hypergraph).
 
 """
+
 from itertools import combinations
 
 from ..exception import XGIError

--- a/xgi/generators/uniform.py
+++ b/xgi/generators/uniform.py
@@ -1,4 +1,5 @@
 """Generate random uniform hypergraphs."""
+
 import itertools
 import operator
 import random

--- a/xgi/linalg/hodge_matrix.py
+++ b/xgi/linalg/hodge_matrix.py
@@ -43,6 +43,7 @@ array([[1, 0, 0],
        [1, 0, 1]])
 
 """
+
 import numpy as np
 
 __all__ = [

--- a/xgi/linalg/hypergraph_matrix.py
+++ b/xgi/linalg/hypergraph_matrix.py
@@ -43,6 +43,7 @@ array([[1, 0, 0],
        [1, 0, 1]])
 
 """
+
 from warnings import catch_warnings, warn
 
 import numpy as np

--- a/xgi/linalg/laplacian_matrix.py
+++ b/xgi/linalg/laplacian_matrix.py
@@ -43,6 +43,7 @@ array([[1, 0, 0],
        [1, 0, 1]])
 
 """
+
 from warnings import warn
 
 import numpy as np

--- a/xgi/readwrite/json.py
+++ b/xgi/readwrite/json.py
@@ -1,4 +1,5 @@
 """Read from and write to JSON."""
+
 import json
 from collections import defaultdict
 from os.path import dirname, join

--- a/xgi/readwrite/xgi_data.py
+++ b/xgi/readwrite/xgi_data.py
@@ -1,4 +1,5 @@
 """Load a data set from the xgi-data repository or a local file."""
+
 from os.path import dirname, exists, join
 from warnings import warn
 

--- a/xgi/utils/utilities.py
+++ b/xgi/utils/utilities.py
@@ -394,7 +394,7 @@ def convert_labels_to_integers(net, label_attribute="label"):
     edge_dict = dict(zip(net.edges, range(net.num_edges)))
 
     temp_net = net.__class__()
-    temp_net._hypergraph = deepcopy(net._hypergraph)
+    temp_net._net_attr = deepcopy(net._net_attr)
 
     temp_net.add_nodes_from((id, deepcopy(net.nodes[n])) for n, id in node_dict.items())
     temp_net.set_node_attributes(


### PR DESCRIPTION
This PR renames the `_hypergraph` internal variable to `_net_attr` to be more descriptive and general. This change does not affect the API.