### PR TITLE
Add support for Python 3.13

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
+        python-version: ['3.9', '3.10', '3.11', '3.12', '3.13']
     steps:
     - uses: actions/checkout@v2
 
@@ -112,7 +112,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu, macos, windows]
-        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
+        python-version: ['3.9', '3.10', '3.11', '3.12', '3.13']
     steps:
     - uses: actions/checkout@v4
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 <img src='https://github.com/xgi-org/xgi/blob/main/logo/logo.svg' alt="XGI" width='50%'></img>
 
 [![Project Status: Active – The project has reached a stable, usable state and is being actively developed.](https://www.repostatus.org/badges/latest/active.svg)](https://www.repostatus.org/#active)
-[![Supports Python versions 3.8 and above.](https://img.shields.io/badge/Python%20versions%20supported-3.8%2B-forest
+[![Supports Python versions 3.9 and above.](https://img.shields.io/badge/Python%20versions%20supported-3.9%2B-forest
 )](https://www.repostatus.org/#active)
 [![Test Status](https://github.com/xgi-org/xgi/workflows/test/badge.svg?branch=main)](https://github.com/xgi-org/xgi/actions?query=workflow%3A%22test%22)
 [![codecov](https://codecov.io/gh/xgi-org/xgi/branch/main/graph/badge.svg?token=BI6TX2WDSG)](https://codecov.io/gh/xgi-org/xgi)
@@ -42,7 +42,7 @@ Comple**X** **G**roup **I**nteractions (**XGI**) is a Python package for higher-
 * Draw higher-order networks in a variety of **visually striking ways** (See our [gallery](https://xgi.readthedocs.io/en/stable/gallery.html) for several examples.)
 
 ## Installation<a id="installation"></a>
-XGI runs on Python 3.8 or higher.
+XGI runs on Python 3.9 or higher.
 
 To install the latest version of XGI, run the following command:
 ```sh

--- a/docs/source/installing.rst
+++ b/docs/source/installing.rst
@@ -13,7 +13,7 @@ To install XGI, execute the following in the command line:
    pip install xgi
 
 
-XGI was developed and tested for Python 3.8-3.12 on Mac OS, Windows, and Ubuntu.
+XGI was developed and tested for Python 3.9-3.13 on Mac OS, Windows, and Ubuntu.
 
 Once installed, go directly to the `User Guides <user_guides.html>`_ to get started!
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "xgi"
 dynamic = ["version"]
 description = "XGI is a Python package for higher-order networks."
 readme = "README.md"
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 license = {file = "LICENSE.md"}
 authors = [
     {name = "XGI Developers", email = "nicholas.landry@virginia.edu"}
@@ -30,11 +30,11 @@ classifiers = [
     "License :: OSI Approved :: BSD License",
     "Operating System :: OS Independent",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
     "Programming Language :: Python :: 3 :: Only",
     "Topic :: Software Development :: Libraries :: Python Modules",
     "Topic :: Scientific/Engineering :: Bio-Informatics",


### PR DESCRIPTION
This PR adds support for Python 3.13 and removes support for Python 3.8 in accordance with the official Python [release schedule](https://devguide.python.org/versions/).