### PR TITLE
Update clustering.py

### DIFF
--- a/tests/algorithms/test_clustering.py
+++ b/tests/algorithms/test_clustering.py
@@ -1,6 +1,7 @@
 import pytest
 
 import xgi
+import networkx as nx
 from xgi.exception import XGIError
 
 
@@ -13,8 +14,9 @@ def test_local_clustering_coefficient(edgelist8):
 
     H = xgi.random_hypergraph(3, [1, 1])
     cc = xgi.local_clustering_coefficient(H)
-    true_cc = {0: 1.0, 1: 1.0, 2: 1.0}
-    assert cc == true_cc
+    true_cc = {0: 0.333, 1: 0.333, 2: 0.333}
+    for n in cc:
+        assert round(cc[n], 3) == true_cc[n]
 
     H = xgi.random_hypergraph(3, [0, 1])
     cc = xgi.local_clustering_coefficient(H)
@@ -33,16 +35,24 @@ def test_local_clustering_coefficient(edgelist8):
     H = xgi.Hypergraph(edgelist8)
     cc = xgi.local_clustering_coefficient(H)
     true_cc = {
-        0: 0.6777777777777778,
-        1: 0.575,
-        2: 0.3333333333333333,
-        3: 0.3333333333333333,
-        4: 0.6666666666666666,
-        5: 0.0,
-        6: 0.0,
+        0: 0.47111111111111115,
+        1: 0.44833333333333336,
+        2: 0.625,
+        3: 0.625,
+        4: 0.5833333333333334,
+        5: 1.0,
+        6: 1.0
     }
     for n in cc:
         assert round(cc[n], 3) == round(true_cc[n], 3)
+        
+    G = nx.erdos_renyi_graph(50, 0.1, seed=0)
+    H = xgi.Hypergraph()
+    H.add_nodes_from(G.nodes)
+    H.add_edges_from(G.edges)
+    cc = nx.clustering(G)
+    lcc = xgi.local_clustering_coefficient(H)
+    assert cc == lcc
 
 
 def test_clustering_coefficient(edgelist1):

--- a/xgi/algorithms/clustering.py
+++ b/xgi/algorithms/clustering.py
@@ -119,7 +119,7 @@ def local_clustering_coefficient(H):
     >>> H = xgi.random_hypergraph(3, [1, 1])
     >>> cc = xgi.local_clustering_coefficient(H)
     >>> cc
-    {0: 1.0, 1: 1.0, 2: 1.0}
+    {0: 0.3333333333333333, 1: 0.3333333333333333, 2: 0.3333333333333333}
 
     """
     result = {}

--- a/xgi/algorithms/clustering.py
+++ b/xgi/algorithms/clustering.py
@@ -1,6 +1,7 @@
 """Algorithms for computing nodal clustering coefficients."""
 
 import numpy as np
+from itertools import combinations
 
 from ..exception import XGIError
 from ..linalg import adjacency_matrix
@@ -134,30 +135,29 @@ def local_clustering_coefficient(H):
         else:
             total_eo = 0
             # go over all pairs of edges pairwise
-            for e1 in range(dv):
+            for e1, e2 in combinations(ev, 2):
                 edge1 = members[e1]
-                for e2 in range(e1):
-                    edge2 = members[e2]
-                    # set differences for the hyperedges
-                    D1 = set(edge1) - set(edge2)
-                    D2 = set(edge2) - set(edge1)
-                    # if edges are the same by definition the extra overlap is zero
-                    if len(D1.union(D2)) == 0:
-                        eo = 0
-                    else:
-                        # otherwise we have to look at their neighbours
-                        # the neighbours of D1 and D2, respectively.
-                        neighD1 = {i for d in D1 for i in H.nodes.neighbors(d)}
-                        neighD2 = {i for d in D2 for i in H.nodes.neighbors(d)}
-                        # compute extra overlap [len() is used for cardinality of edges]
-                        eo = (
-                            len(neighD1.intersection(D2))
-                            + len(neighD2.intersection(D1))
-                        ) / len(
-                            D1.union(D2)
-                        )  # add it up
-                    # add it up
-                    total_eo = total_eo + eo
+                edge2 = members[e2]
+                # set differences for the hyperedges
+                D1 = set(edge1) - set(edge2)
+                D2 = set(edge2) - set(edge1)
+                # if edges are the same by definition the extra overlap is zero
+                if len(D1.union(D2)) == 0:
+                    eo = 0
+                else:
+                    # otherwise we have to look at their neighbours
+                    # the neighbours of D1 and D2, respectively.
+                    neighD1 = {i for d in D1 for i in H.nodes.neighbors(d)}
+                    neighD2 = {i for d in D2 for i in H.nodes.neighbors(d)}
+                    # compute extra overlap [len() is used for cardinality of edges]
+                    eo = (
+                        len(neighD1.intersection(D2))
+                        + len(neighD2.intersection(D1))
+                    ) / len(
+                        D1.union(D2)
+                    )  # add it up
+                # add it up
+                total_eo = total_eo + eo
 
             # include normalisation by degree k*(k-1)/2
             result[n] = 2 * total_eo / (dv * (dv - 1))

--- a/xgi/stats/nodestats.py
+++ b/xgi/stats/nodestats.py
@@ -265,7 +265,7 @@ def local_clustering_coefficient(net, bunch):
     >>> import xgi
     >>> H = xgi.random_hypergraph(3, [1, 1])
     >>> H.nodes.local_clustering_coefficient.asdict()
-    {0: 1.0, 1: 1.0, 2: 1.0}
+    {0: 0.3333333333333333, 1: 0.3333333333333333, 2: 0.3333333333333333}
 
     """
     cc = xgi.local_clustering_coefficient(net)


### PR DESCRIPTION
Fixing local_clustering_coefficient function.

I think that the two 'for' cycles are not correct because 'range(dv)' does not identify the hyper-edges to which the node n belongs.
Since we have to go over all the possible pairs of hyperedges (without repetitions) containing the node n, I guess that one possible correct implementation may be:  'for e1, e2 in combinations(ev, 2)'.