### PR TITLE
Integrate HIF with more of XGI

### DIFF
--- a/HOW_TO_CONTRIBUTE.md
+++ b/HOW_TO_CONTRIBUTE.md
@@ -9,7 +9,7 @@ Please note we have a [code of conduct](/CODE_OF_CONDUCT.md), please follow it i
 1. Download the dependencies in the developer [requirements file](/requirements/developer.txt).
 2. Add unit tests for features being added or bugs being fixed.
 3. Include any new method/function in the corresponding docs file.
-4. Run `pytest` to verify all unit tests pass.
+4. Run `pytest` to verify all unit tests pass. (If you want to see the overall coverage, run `pytest --cov=xgi tests` and to see the missing lines, run `pytest  --cov-report term-missing --cov=xgi tests`)
 5. Identify the unnecessary imports in the
    1. source code by running `pylint xgi/ --disable=all --enable W0611`
    2. notebooks by running `nbqa pylint . --disable=all --enable W0611`

--- a/HOW_TO_CONTRIBUTE.md
+++ b/HOW_TO_CONTRIBUTE.md
@@ -9,7 +9,7 @@ Please note we have a [code of conduct](/CODE_OF_CONDUCT.md), please follow it i
 1. Download the dependencies in the developer [requirements file](/requirements/developer.txt).
 2. Add unit tests for features being added or bugs being fixed.
 3. Include any new method/function in the corresponding docs file.
-4. Run `pytest` to verify all unit tests pass. (If you want to see the overall test coverage, run `pytest --cov=xgi tests` and to see the lines of code not covered by tests, run `pytest  --cov-report term-missing --cov=xgi tests`)
+4. Run `pytest` to verify all unit tests pass. (To see what lines are covered, read the [`pytest-cov`](https://pytest-cov.readthedocs.io/en/latest/reporting.html) documentation.)
 5. [OPTIONAL] Format codebase according to the steps below.
 5. Submit Pull Request with a list of changes, links to issues that it addresses (if applicable)
 6. You may merge the Pull Request in once you have the sign-off of at least one other developer, or if you do not have permission to do that, you may request the reviewer to merge it for you.

--- a/docs/source/api/convert.rst
+++ b/docs/source/api/convert.rst
@@ -11,6 +11,7 @@ convert package
    ~xgi.convert.bipartite_graph
    ~xgi.convert.encapsulation_dag
    ~xgi.convert.graph
+   ~xgi.convert.hif_dict
    ~xgi.convert.higher_order_network
    ~xgi.convert.hyperedges
    ~xgi.convert.hypergraph_dict

--- a/docs/source/api/convert/xgi.convert.hif_dict.rst
+++ b/docs/source/api/convert/xgi.convert.hif_dict.rst
@@ -1,0 +1,11 @@
+xgi.convert.hif_dict
+====================
+
+.. currentmodule:: xgi.convert.hif_dict
+
+.. automodule:: xgi.convert.hif_dict
+   
+   .. rubric:: Functions
+   
+   .. autofunction:: to_hif_dict
+   .. autofunction:: from_hif_dict

--- a/docs/source/api/readwrite/xgi.readwrite.hif.rst
+++ b/docs/source/api/readwrite/xgi.readwrite.hif.rst
@@ -8,4 +8,6 @@ xgi.readwrite.hif
    .. rubric:: Functions
 
    .. autofunction:: read_hif
+   .. autofunction:: read_hif_collection
    .. autofunction:: write_hif
+   .. autofunction:: write_hif_collection

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -14,9 +14,9 @@
 import os
 import sys
 from datetime import date, datetime
-from sphinx_gallery.sorting import ExplicitOrder, FileNameSortKey
 
 import requests
+from sphinx_gallery.sorting import ExplicitOrder, FileNameSortKey
 
 import xgi
 

--- a/docs/source/xgi-data.rst
+++ b/docs/source/xgi-data.rst
@@ -30,7 +30,7 @@ See the `load_bigg_data() documentation <api/readwrite/xgi.readwrite.bigg_data.h
 Dataset format
 --------------
 
-The xgi-data format for higher-order datasets is a JSON data structure with the following structure:
+XGI-DATA provides higher-order datasets in two formats: (1) Hypergraph Interchange Format (HIF)-compliant JSON (2) XGI-specific JSON format. See the `HIF-standard <https://github.com/pszufe/HIF-standard>`_ documentation on format (1). Format (2) is structured as follows:
 
 * :code:`hypergraph-data`: This tag accesses the attributes of the entire hypergraph dataset such as the authors or dataset name.
 

--- a/docs/source/xgi-data.rst
+++ b/docs/source/xgi-data.rst
@@ -30,7 +30,9 @@ See the `load_bigg_data() documentation <api/readwrite/xgi.readwrite.bigg_data.h
 Dataset format
 --------------
 
-XGI-DATA provides higher-order datasets in two formats: (1) Hypergraph Interchange Format (HIF)-compliant JSON (2) XGI-specific JSON format. See the `HIF-standard <https://github.com/pszufe/HIF-standard>`_ documentation on format (1). Format (2) is structured as follows:
+XGI-DATA provides higher-order datasets in two formats: (1) Hypergraph Interchange Format (HIF)-compliant JSON (2) XGI-specific JSON format. See the `HIF-standard <https://github.com/pszufe/HIF-standard>`_ documentation on format (1).
+All future datasets and updates to current datasets will be stored as format (1).
+Format (2) is structured as follows:
 
 * :code:`hypergraph-data`: This tag accesses the attributes of the entire hypergraph dataset such as the authors or dataset name.
 

--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -11,3 +11,4 @@ ipykernel
 nbsphinx
 nbsphinx-link
 pydata-sphinx-theme
+sphinx-gallery

--- a/requirements/release.txt
+++ b/requirements/release.txt
@@ -3,4 +3,3 @@
 twine>=3.4
 build>=1.2.1
 wheel>=0.36
-github-changelog

--- a/tests/algorithms/test_clustering.py
+++ b/tests/algorithms/test_clustering.py
@@ -1,6 +1,7 @@
 import pytest
 
 import xgi
+import networkx as nx
 from xgi.exception import XGIError
 
 
@@ -13,8 +14,9 @@ def test_local_clustering_coefficient(edgelist8):
 
     H = xgi.random_hypergraph(3, [1, 1])
     cc = xgi.local_clustering_coefficient(H)
-    true_cc = {0: 1.0, 1: 1.0, 2: 1.0}
-    assert cc == true_cc
+    true_cc = {0: 0.333, 1: 0.333, 2: 0.333}
+    for n in cc:
+        assert round(cc[n], 3) == true_cc[n]
 
     H = xgi.random_hypergraph(3, [0, 1])
     cc = xgi.local_clustering_coefficient(H)
@@ -33,16 +35,24 @@ def test_local_clustering_coefficient(edgelist8):
     H = xgi.Hypergraph(edgelist8)
     cc = xgi.local_clustering_coefficient(H)
     true_cc = {
-        0: 0.6777777777777778,
-        1: 0.575,
-        2: 0.3333333333333333,
-        3: 0.3333333333333333,
-        4: 0.6666666666666666,
-        5: 0.0,
-        6: 0.0,
+        0: 0.47111111111111115,
+        1: 0.44833333333333336,
+        2: 0.625,
+        3: 0.625,
+        4: 0.5833333333333334,
+        5: 1.0,
+        6: 1.0
     }
     for n in cc:
         assert round(cc[n], 3) == round(true_cc[n], 3)
+        
+    G = nx.erdos_renyi_graph(50, 0.1, seed=0)
+    H = xgi.Hypergraph()
+    H.add_nodes_from(G.nodes)
+    H.add_edges_from(G.edges)
+    cc = nx.clustering(G)
+    lcc = xgi.local_clustering_coefficient(H)
+    assert cc == lcc
 
 
 def test_clustering_coefficient(edgelist1):

--- a/tests/algorithms/test_clustering.py
+++ b/tests/algorithms/test_clustering.py
@@ -1,7 +1,7 @@
+import networkx as nx
 import pytest
 
 import xgi
-import networkx as nx
 from xgi.exception import XGIError
 
 
@@ -41,11 +41,11 @@ def test_local_clustering_coefficient(edgelist8):
         3: 0.625,
         4: 0.5833333333333334,
         5: 1.0,
-        6: 1.0
+        6: 1.0,
     }
     for n in cc:
         assert round(cc[n], 3) == round(true_cc[n], 3)
-        
+
     G = nx.erdos_renyi_graph(50, 0.1, seed=0)
     H = xgi.Hypergraph()
     H.add_nodes_from(G.nodes)

--- a/tests/drawing/test_draw.py
+++ b/tests/drawing/test_draw.py
@@ -33,7 +33,7 @@ def test_draw(edgelist8):
         assert patch.get_zorder() == z
     assert node_collection.get_zorder() == 4  # nodes
 
-    plt.close()
+    plt.close("all")
 
     # simplicial complex
     S = xgi.SimplicialComplex(edgelist8)
@@ -58,7 +58,7 @@ def test_draw(edgelist8):
     for patch, z in zip(ax.patches, [0, 2, 2]):  # hyperedges
         assert patch.get_zorder() == z
 
-    plt.close()
+    plt.close("all")
 
 
 def test_draw_nodes(edgelist8):
@@ -116,10 +116,10 @@ def test_draw_nodes(edgelist8):
     # negative node_lw or node_size
     with pytest.raises(ValueError):
         ax3, node_collection3 = xgi.draw_nodes(H, node_size=-1)
-        plt.close()
+        plt.close("all")
     with pytest.raises(ValueError):
         ax3, node_collection3 = xgi.draw_nodes(H, node_lw=-1)
-        plt.close()
+        plt.close("all")
 
     plt.close("all")
 
@@ -132,14 +132,14 @@ def test_draw_nodes_fc_cmap(edgelist8):
     fig, ax = plt.subplots()
     ax, node_collection = xgi.draw_nodes(H, ax=ax, node_fc="r")
     assert node_collection.get_cmap() == plt.cm.viridis
-    plt.close()
+    plt.close("all")
 
     # default cmap
     fig, ax = plt.subplots()
     colors = [11, 12, 14, 16, 17, 19, 21]
     ax, node_collection = xgi.draw_nodes(H, ax=ax, node_fc=colors)
     assert node_collection.get_cmap() == plt.cm.Reds
-    plt.close()
+    plt.close("all")
 
     # set cmap
     fig, ax = plt.subplots()
@@ -148,13 +148,13 @@ def test_draw_nodes_fc_cmap(edgelist8):
     )
     assert node_collection.get_cmap() == plt.cm.Greens
     assert (min(colors), max(colors)) == node_collection.get_clim()
-    plt.close()
+    plt.close("all")
 
     # vmin/vmax
     fig, ax = plt.subplots()
     ax, node_collection = xgi.draw_nodes(H, ax=ax, node_fc=colors, vmin=14, vmax=19)
     assert (14, 19) == node_collection.get_clim()
-    plt.close()
+    plt.close("all")
 
 
 def test_draw_nodes_interp(edgelist8):
@@ -168,7 +168,7 @@ def test_draw_nodes_interp(edgelist8):
     ax, node_collection = xgi.draw_nodes(H, ax=ax, node_size=1, node_lw=10)
     assert np.all(node_collection.get_sizes() == np.array([1]))
     assert np.all(node_collection.get_linewidth() == np.array([10]))
-    plt.close()
+    plt.close("all")
 
     # rescaling does not affect scalars
     fig, ax = plt.subplots()
@@ -177,7 +177,7 @@ def test_draw_nodes_interp(edgelist8):
     )
     assert np.all(node_collection.get_sizes() == np.array([1]))
     assert np.all(node_collection.get_linewidth() == np.array([10]))
-    plt.close()
+    plt.close("all")
 
     # not rescaling IDStat
     fig, ax = plt.subplots()
@@ -186,7 +186,7 @@ def test_draw_nodes_interp(edgelist8):
     )
     assert np.all(node_collection.get_sizes() == deg_arr**2)
     assert np.all(node_collection.get_linewidth() == deg_arr)
-    plt.close()
+    plt.close("all")
 
     # rescaling IDStat
     fig, ax = plt.subplots()
@@ -197,7 +197,7 @@ def test_draw_nodes_interp(edgelist8):
     assert max(node_collection.get_sizes()) == 30**2
     assert min(node_collection.get_linewidth()) == 0
     assert max(node_collection.get_linewidth()) == 5
-    plt.close()
+    plt.close("all")
 
     # rescaling IDStat with manual values
     fig, ax = plt.subplots()
@@ -218,7 +218,7 @@ def test_draw_nodes_interp(edgelist8):
     assert max(node_collection.get_sizes()) == 20**2
     assert min(node_collection.get_linewidth()) == 1
     assert max(node_collection.get_linewidth()) == 10
-    plt.close()
+    plt.close("all")
 
     # rescaling ndarray
     fig, ax = plt.subplots()
@@ -229,7 +229,7 @@ def test_draw_nodes_interp(edgelist8):
     assert max(node_collection.get_sizes()) == 30**2
     assert min(node_collection.get_linewidth()) == 0
     assert max(node_collection.get_linewidth()) == 5
-    plt.close()
+    plt.close("all")
 
 
 def test_draw_hyperedges(edgelist8):
@@ -281,7 +281,7 @@ def test_draw_hyperedges(edgelist8):
     with pytest.raises(ValueError):
         ax, collections = xgi.draw_hyperedges(H, ax=ax, dyad_lw=-1)
         (dyad_collection, edge_collection) = collections
-        plt.close()
+        plt.close("all")
 
     plt.close("all")
 
@@ -296,7 +296,7 @@ def test_draw_hyperedges_fc_cmap(edgelist8):
     (dyad_collection, edge_collection) = collections
     assert dyad_collection.get_cmap() == plt.cm.Greys
     assert edge_collection.get_cmap() == sb.color_palette("crest_r", as_cmap=True)
-    plt.close()
+    plt.close("all")
 
     # set cmap
     fig, ax = plt.subplots()
@@ -313,7 +313,7 @@ def test_draw_hyperedges_fc_cmap(edgelist8):
 
     assert (min(dyad_colors), max(dyad_colors)) == dyad_collection.get_clim()
     assert (3, 5) == edge_collection.get_clim()
-    plt.close()
+    plt.close("all")
 
     # vmin/vmax
     fig, ax = plt.subplots()
@@ -332,7 +332,7 @@ def test_draw_hyperedges_fc_cmap(edgelist8):
     assert (14, 19) == edge_collection.get_clim()
     assert (5, 6) == dyad_collection.get_clim()
 
-    plt.close()
+    plt.close("all")
 
 
 def test_draw_hyperedges_ec(edgelist8):
@@ -364,7 +364,7 @@ def test_draw_simplices(edgelist8):
     with pytest.raises(XGIError):
         H = xgi.Hypergraph(edgelist8)
         ax = xgi.draw_simplices(H)
-        plt.close()
+        plt.close("all")
 
     S = xgi.SimplicialComplex(edgelist8)
 
@@ -386,7 +386,7 @@ def test_draw_simplices(edgelist8):
     for patch, z in zip(ax.patches, [0, 2, 2]):  # hyperedges
         assert patch.get_zorder() == z
 
-    plt.close()
+    plt.close("all")
 
 
 def test_draw_hypergraph_hull(edgelist8):
@@ -414,7 +414,7 @@ def test_draw_hypergraph_hull(edgelist8):
         assert patch.get_zorder() == z
     assert node_collection.get_zorder() == 4  # nodes
 
-    plt.close()
+    plt.close("all")
 
 
 def test_draw_multilayer(edgelist8):
@@ -461,7 +461,7 @@ def test_draw_multilayer(edgelist8):
     # node_size
     assert np.all(node_coll.get_sizes() == np.array([5**2]))
 
-    plt.close()
+    plt.close("all")
 
     # max_order parameter
     max_order = 2
@@ -484,7 +484,7 @@ def test_draw_multilayer(edgelist8):
 
     offsets = node_coll2.get_offsets()
     assert offsets.shape[0] == H.num_nodes  # nodes
-    plt.close()
+    plt.close("all")
 
     # conn_lines parameter
     ax3, (node_coll3, edge_coll3) = xgi.draw_multilayer(H, conn_lines=False)
@@ -503,7 +503,7 @@ def test_draw_multilayer(edgelist8):
         + num_dyad_collections
         == len(ax3.collections)
     )
-    plt.close()
+    plt.close("all")
 
     # custom parameters
     pos = xgi.circular_layout(H)

--- a/xgi/algorithms/clustering.py
+++ b/xgi/algorithms/clustering.py
@@ -1,6 +1,7 @@
 """Algorithms for computing nodal clustering coefficients."""
 
 import numpy as np
+from itertools import combinations
 
 from ..exception import XGIError
 from ..linalg import adjacency_matrix
@@ -118,7 +119,7 @@ def local_clustering_coefficient(H):
     >>> H = xgi.random_hypergraph(3, [1, 1])
     >>> cc = xgi.local_clustering_coefficient(H)
     >>> cc
-    {0: 1.0, 1: 1.0, 2: 1.0}
+    {0: 0.3333333333333333, 1: 0.3333333333333333, 2: 0.3333333333333333}
 
     """
     result = {}
@@ -134,30 +135,29 @@ def local_clustering_coefficient(H):
         else:
             total_eo = 0
             # go over all pairs of edges pairwise
-            for e1 in range(dv):
+            for e1, e2 in combinations(ev, 2):
                 edge1 = members[e1]
-                for e2 in range(e1):
-                    edge2 = members[e2]
-                    # set differences for the hyperedges
-                    D1 = set(edge1) - set(edge2)
-                    D2 = set(edge2) - set(edge1)
-                    # if edges are the same by definition the extra overlap is zero
-                    if len(D1.union(D2)) == 0:
-                        eo = 0
-                    else:
-                        # otherwise we have to look at their neighbours
-                        # the neighbours of D1 and D2, respectively.
-                        neighD1 = {i for d in D1 for i in H.nodes.neighbors(d)}
-                        neighD2 = {i for d in D2 for i in H.nodes.neighbors(d)}
-                        # compute extra overlap [len() is used for cardinality of edges]
-                        eo = (
-                            len(neighD1.intersection(D2))
-                            + len(neighD2.intersection(D1))
-                        ) / len(
-                            D1.union(D2)
-                        )  # add it up
-                    # add it up
-                    total_eo = total_eo + eo
+                edge2 = members[e2]
+                # set differences for the hyperedges
+                D1 = set(edge1) - set(edge2)
+                D2 = set(edge2) - set(edge1)
+                # if edges are the same by definition the extra overlap is zero
+                if len(D1.union(D2)) == 0:
+                    eo = 0
+                else:
+                    # otherwise we have to look at their neighbours
+                    # the neighbours of D1 and D2, respectively.
+                    neighD1 = {i for d in D1 for i in H.nodes.neighbors(d)}
+                    neighD2 = {i for d in D2 for i in H.nodes.neighbors(d)}
+                    # compute extra overlap [len() is used for cardinality of edges]
+                    eo = (
+                        len(neighD1.intersection(D2))
+                        + len(neighD2.intersection(D1))
+                    ) / len(
+                        D1.union(D2)
+                    )  # add it up
+                # add it up
+                total_eo = total_eo + eo
 
             # include normalisation by degree k*(k-1)/2
             result[n] = 2 * total_eo / (dv * (dv - 1))

--- a/xgi/algorithms/clustering.py
+++ b/xgi/algorithms/clustering.py
@@ -1,7 +1,8 @@
 """Algorithms for computing nodal clustering coefficients."""
 
-import numpy as np
 from itertools import combinations
+
+import numpy as np
 
 from ..exception import XGIError
 from ..linalg import adjacency_matrix
@@ -151,8 +152,7 @@ def local_clustering_coefficient(H):
                     neighD2 = {i for d in D2 for i in H.nodes.neighbors(d)}
                     # compute extra overlap [len() is used for cardinality of edges]
                     eo = (
-                        len(neighD1.intersection(D2))
-                        + len(neighD2.intersection(D1))
+                        len(neighD1.intersection(D2)) + len(neighD2.intersection(D1))
                     ) / len(
                         D1.union(D2)
                     )  # add it up

--- a/xgi/convert/__init__.py
+++ b/xgi/convert/__init__.py
@@ -3,6 +3,7 @@ from . import (
     bipartite_graph,
     encapsulation_dag,
     graph,
+    hif_dict,
     higher_order_network,
     hyperedges,
     hypergraph_dict,
@@ -15,6 +16,7 @@ from .bipartite_edges import *
 from .bipartite_graph import *
 from .encapsulation_dag import *
 from .graph import *
+from .hif_dict import *
 from .higher_order_network import *
 from .hyperedges import *
 from .hypergraph_dict import *

--- a/xgi/convert/hif_dict.py
+++ b/xgi/convert/hif_dict.py
@@ -1,3 +1,5 @@
+"""Methods for converting to/from HIF standard."""
+
 from collections import defaultdict
 
 from ..core import DiHypergraph, Hypergraph, SimplicialComplex
@@ -8,6 +10,21 @@ __all__ = ["to_hif_dict", "from_hif_dict"]
 
 
 def to_hif_dict(H):
+    """
+    A function to create a dictionary according to the HIF standard from a higher-order network.
+
+    For more information, see the HIF `project <https://github.com/pszufe/HIF_validators>`_.
+
+    Parameters
+    ----------
+    H: Hypergraph, DiHypergraph, or SimplicialComplex object
+        The specified higher-order network
+
+    Returns
+    -------
+    defaultdict
+        A dict according to the HIF standard.
+    """
     data = defaultdict(list)
 
     data["metadata"] = {}
@@ -49,7 +66,7 @@ def to_hif_dict(H):
 
 def from_hif_dict(data, nodetype=None, edgetype=None):
     """
-    A helper function to read a file created according to the HIF format.
+    A function to read a dictionary that follows the HIF standard.
 
     For more information, see the HIF `project <https://github.com/pszufe/HIF_validators>`_.
 

--- a/xgi/convert/hif_dict.py
+++ b/xgi/convert/hif_dict.py
@@ -1,0 +1,142 @@
+from collections import defaultdict
+
+from ..core import DiHypergraph, Hypergraph, SimplicialComplex
+from ..utils import IDDict
+from .bipartite_edges import to_bipartite_edgelist
+
+__all__ = ["to_hif_dict", "from_hif_dict"]
+
+
+def to_hif_dict(H):
+    data = defaultdict(list)
+
+    data["metadata"] = {}
+    data["metadata"].update(H._net_attr)
+
+    if isinstance(H, SimplicialComplex):
+        data["network-type"] = "asc"
+    elif isinstance(H, Hypergraph):
+        data["network-type"] = "undirected"
+    elif isinstance(H, DiHypergraph):
+        data["network-type"] = "directed"
+
+    # get node data
+    isolates = set(H.nodes.isolates())
+    nodes_with_attrs = set(n for n in H.nodes if H.nodes[n])
+    for n in isolates.union(nodes_with_attrs):
+        attr = {"attrs": H.nodes[n]} if H.nodes[n] else {}
+        data["nodes"].append(IDDict({"node": n}) + attr)
+
+    empty = set(H.edges.empty())
+    edges_with_attrs = set(e for e in H.edges if H.edges[e])
+    for e in empty.union(edges_with_attrs):
+        attr = {"attrs": H.edges[e]} if H.edges[e] else {}
+        data["edges"].append(IDDict({"edge": e}) + attr)
+
+    # hyperedge dict
+    if data["network-type"] == "directed":
+        _convert_d = lambda d: "tail" if d == "in" else "head"
+        data["incidences"] = [
+            IDDict({"edge": e, "node": n, "direction": _convert_d(d)})
+            for n, e, d in to_bipartite_edgelist(H)
+        ]
+    elif data["network-type"] in {"undirected", "asc"}:
+        data["incidences"] = [
+            IDDict({"edge": e, "node": n}) for n, e in to_bipartite_edgelist(H)
+        ]
+    return data
+
+
+def from_hif_dict(data, nodetype=None, edgetype=None):
+    """
+    A helper function to read a file created according to the HIF format.
+
+    For more information, see the HIF `project <https://github.com/pszufe/HIF_validators>`_.
+
+    Parameters
+    ----------
+    data: dict
+        A dictionary in the hypergraph JSON format
+    nodetype: type, optional
+        Type that the node IDs will be cast to
+    edgetype: type, optional
+        Type that the edge IDs will be cast to
+
+    Returns
+    -------
+    A Hypergraph, SimplicialComplex, or DiHypergraph object
+        The loaded network
+    """
+
+    def _empty_edge(network_type):
+        if network_type in {"asc", "undirected"}:
+            return set()
+        else:
+            return (set(), set())
+
+    def _convert_id(i, idtype):
+        if idtype:
+            try:
+                return idtype(i)
+            except ValueError as e:
+                raise TypeError(f"Failed to convert ID {i} to type {idtype}.") from e
+        else:
+            return i
+
+    _convert_d = lambda d: "in" if d == "tail" else "out"
+
+    if "network-type" in data:
+        network_type = data["network-type"]
+    else:
+        network_type = "undirected"
+
+    if network_type in {"asc", "undirected"}:
+        G = Hypergraph()
+    elif network_type == "directed":
+        G = DiHypergraph()
+
+    # Import network metadata
+    if "metadata" in data:
+        G._net_attr.update(data["metadata"])
+
+    for record in data["incidences"]:
+        n = _convert_id(record["node"], nodetype)
+        e = _convert_id(record["edge"], edgetype)
+
+        if network_type == "directed":
+            d = record["direction"]
+            d = _convert_d(d)  # convert from head/tail to in/out
+            G.add_node_to_edge(e, n, d)
+        else:
+            G.add_node_to_edge(e, n)
+
+    # import node attributes if they exist
+    if "nodes" in data:
+        for record in data["nodes"]:
+            n = _convert_id(record["node"], nodetype)
+            if "attrs" in record:
+                attr = record["attrs"]
+            else:
+                attr = {}
+
+            if n not in G._node:
+                G.add_node(n, **attr)
+            else:
+                G.set_node_attributes({n: attr})
+
+    # import edge attributes if they exist
+    if "edges" in data:
+        for record in data["edges"]:
+            e = _convert_id(record["edge"], edgetype)
+            if "attrs" in record:
+                attr = record["attrs"]
+            else:
+                attr = {}
+            if e not in G._edge:
+                G.add_edge(_empty_edge(network_type), e, **attr)
+            else:
+                G.set_edge_attributes({e: attr})
+
+    if network_type == "asc":
+        G = SimplicialComplex(G)
+    return G

--- a/xgi/readwrite/hif.py
+++ b/xgi/readwrite/hif.py
@@ -11,7 +11,7 @@ from os.path import dirname, join
 from ..convert import from_hif_dict, to_hif_dict
 from ..exception import XGIError
 
-__all__ = ["write_hif", "read_hif"]
+__all__ = ["write_hif", "write_hif_collection", "read_hif", "read_hif_collection"]
 
 
 def write_hif(H, path):

--- a/xgi/readwrite/hif.py
+++ b/xgi/readwrite/hif.py
@@ -5,16 +5,13 @@ HIF `project <https://github.com/pszufe/HIF_validators>`_.
 """
 
 import json
-from collections import defaultdict
 
-from ..convert import to_bipartite_edgelist
-from ..core import DiHypergraph, Hypergraph, SimplicialComplex
-from ..utils import IDDict
+from ..convert import from_hif_dict, to_hif_dict
 
 __all__ = ["write_hif", "read_hif"]
 
 
-def write_hif(G, path):
+def write_hif(H, path):
     """
     A function to write a higher-order network according to the HIF standard.
 
@@ -22,48 +19,13 @@ def write_hif(G, path):
 
     Parameters
     ----------
-    G: Hypergraph, DiHypergraph, or SimplicialComplex object
+    H: Hypergraph, DiHypergraph, or SimplicialComplex object
         The specified higher-order network
     path: string
         The path of the file to read from
     """
     # initialize empty data
-    data = defaultdict(list)
-
-    data["metadata"] = {}
-    data["metadata"].update(G._net_attr)
-
-    if isinstance(G, SimplicialComplex):
-        data["network-type"] = "asc"
-    elif isinstance(G, Hypergraph):
-        data["network-type"] = "undirected"
-    elif isinstance(G, DiHypergraph):
-        data["network-type"] = "directed"
-
-    # get node data
-    isolates = set(G.nodes.isolates())
-    nodes_with_attrs = set(n for n in G.nodes if G.nodes[n])
-    for n in isolates.union(nodes_with_attrs):
-        attr = {"attrs": G.nodes[n]} if G.nodes[n] else {}
-        data["nodes"].append(IDDict({"node": n}) + attr)
-
-    empty = set(G.edges.empty())
-    edges_with_attrs = set(e for e in G.edges if G.edges[e])
-    for e in empty.union(edges_with_attrs):
-        attr = {"attrs": G.edges[e]} if G.edges[e] else {}
-        data["edges"].append(IDDict({"edge": e}) + attr)
-
-    # hyperedge dict
-    if data["network-type"] == "directed":
-        _convert_d = lambda d: "tail" if d == "in" else "head"
-        data["incidences"] = [
-            IDDict({"edge": e, "node": n, "direction": _convert_d(d)})
-            for n, e, d in to_bipartite_edgelist(G)
-        ]
-    elif data["network-type"] in {"undirected", "asc"}:
-        data["incidences"] = [
-            IDDict({"edge": e, "node": n}) for n, e in to_bipartite_edgelist(G)
-        ]
+    data = to_hif_dict(H)
 
     datastring = json.dumps(data, indent=2)
 
@@ -94,99 +56,4 @@ def read_hif(path, nodetype=None, edgetype=None):
     with open(path) as file:
         data = json.loads(file.read())
 
-    return _from_dict(data, nodetype=nodetype, edgetype=edgetype)
-
-
-def _from_dict(data, nodetype=None, edgetype=None):
-    """
-    A helper function to read a file created according to the HIF format.
-
-    For more information, see the HIF `project <https://github.com/pszufe/HIF_validators>`_.
-
-    Parameters
-    ----------
-    data: dict
-        A dictionary in the hypergraph JSON format
-    nodetype: type, optional
-        Type that the node IDs will be cast to
-    edgetype: type, optional
-        Type that the edge IDs will be cast to
-
-    Returns
-    -------
-    A Hypergraph, SimplicialComplex, or DiHypergraph object
-        The loaded network
-    """
-
-    def _empty_edge(network_type):
-        if network_type in {"asc", "undirected"}:
-            return set()
-        else:
-            return (set(), set())
-
-    def _convert_id(i, idtype):
-        if idtype:
-            try:
-                return idtype(i)
-            except ValueError as e:
-                raise TypeError(f"Failed to convert ID {i} to type {idtype}.") from e
-        else:
-            return i
-
-    _convert_d = lambda d: "in" if d == "tail" else "out"
-
-    if "network-type" in data:
-        network_type = data["network-type"]
-    else:
-        network_type = "undirected"
-
-    if network_type in {"asc", "undirected"}:
-        G = Hypergraph()
-    elif network_type == "directed":
-        G = DiHypergraph()
-
-    # Import network metadata
-    if "metadata" in data:
-        G._net_attr.update(data["metadata"])
-
-    for record in data["incidences"]:
-        n = _convert_id(record["node"], nodetype)
-        e = _convert_id(record["edge"], edgetype)
-
-        if network_type == "directed":
-            d = record["direction"]
-            d = _convert_d(d)  # convert from head/tail to in/out
-            G.add_node_to_edge(e, n, d)
-        else:
-            G.add_node_to_edge(e, n)
-
-    # import node attributes if they exist
-    if "nodes" in data:
-        for record in data["nodes"]:
-            n = _convert_id(record["node"], nodetype)
-            if "attrs" in record:
-                attr = record["attrs"]
-            else:
-                attr = {}
-
-            if n not in G._node:
-                G.add_node(n, **attr)
-            else:
-                G.set_node_attributes({n: attr})
-
-    # import edge attributes if they exist
-    if "edges" in data:
-        for record in data["edges"]:
-            e = _convert_id(record["edge"], edgetype)
-            if "attrs" in record:
-                attr = record["attrs"]
-            else:
-                attr = {}
-            if e not in G._edge:
-                G.add_edge(_empty_edge(network_type), e, **attr)
-            else:
-                G.set_edge_attributes({e: attr})
-
-    if network_type == "asc":
-        G = SimplicialComplex(G)
-    return G
+    return from_hif_dict(data, nodetype=nodetype, edgetype=edgetype)

--- a/xgi/readwrite/hif.py
+++ b/xgi/readwrite/hif.py
@@ -5,8 +5,11 @@ HIF `project <https://github.com/pszufe/HIF_validators>`_.
 """
 
 import json
+from collections import defaultdict
+from os.path import dirname, join
 
 from ..convert import from_hif_dict, to_hif_dict
+from ..exception import XGIError
 
 __all__ = ["write_hif", "read_hif"]
 
@@ -24,13 +27,56 @@ def write_hif(H, path):
     path: string
         The path of the file to read from
     """
-    # initialize empty data
     data = to_hif_dict(H)
 
     datastring = json.dumps(data, indent=2)
 
     with open(path, "w") as output_file:
         output_file.write(datastring)
+
+
+def write_hif_collection(H, path, collection_name=""):
+    """
+    A function to write a collection of higher-order network according to the HIF standard.
+
+    For more information, see the HIF `project <https://github.com/pszufe/HIF_validators>`_.
+
+    Parameters
+    ----------
+    H: list or dict of Hypergraph, DiHypergraph, or SimplicialComplex objects
+        The specified higher-order network
+    path: string
+        The path of the file to read from
+    """
+    if isinstance(H, list):
+        collection_data = defaultdict(dict)
+        for i, H in enumerate(H):
+            fname = f"{path}/{collection_name}_{i}.json"
+            collection_data["datasets"][i] = {
+                "relative-path": f"{collection_name}_{i}.json"
+            }
+            write_hif(H, fname)
+        collection_data["type"] = "collection"
+        datastring = json.dumps(collection_data, indent=2)
+        with open(
+            f"{path}/{collection_name}_collection_information.json", "w"
+        ) as output_file:
+            output_file.write(datastring)
+
+    elif isinstance(H, dict):
+        collection_data = defaultdict(dict)
+        for name, H in H.items():
+            fname = f"{path}/{collection_name}_{name}.json"
+            collection_data["datasets"][name] = {
+                "relative-path": f"{collection_name}_{name}.json"
+            }
+            write_hif(H, fname)
+        collection_data["type"] = "collection"
+        datastring = json.dumps(collection_data, indent=2)
+        with open(
+            f"{path}/{collection_name}_collection_information.json", "w"
+        ) as output_file:
+            output_file.write(datastring)
 
 
 def read_hif(path, nodetype=None, edgetype=None):
@@ -41,8 +87,8 @@ def read_hif(path, nodetype=None, edgetype=None):
 
     Parameters
     ----------
-    data: dict
-        A dictionary in the hypergraph JSON format
+    path: str
+        The path to the json file
     nodetype: type, optional
         type that the node IDs will be cast to
     edgetype: type, optional
@@ -57,3 +103,43 @@ def read_hif(path, nodetype=None, edgetype=None):
         data = json.loads(file.read())
 
     return from_hif_dict(data, nodetype=nodetype, edgetype=edgetype)
+
+
+def read_hif_collection(path, nodetype=None, edgetype=None):
+    """
+    A function to read a collection of files created according to the HIF format.
+
+    There must be a collection information JSON file which has a top-level field "datasets"
+    with subfields "relative-path", indicating each dataset's location relative to the
+    collection file
+
+    For more information, see the HIF `project <https://github.com/pszufe/HIF_validators>`_.
+
+    Parameters
+    ----------
+    path: str
+        A path to the collection json file.
+    nodetype: type, optional
+        type that the node IDs will be cast to
+    edgetype: type, optional
+        type that the edge IDs will be cast to
+
+    Returns
+    -------
+    A dictionary of Hypergraph, SimplicialComplex, or DiHypergraph objects
+        The collection of networks
+    """
+    with open(path) as file:
+        jsondata = json.loads(file.read())
+
+    try:
+        collection = {}
+        for name, data in jsondata["datasets"].items():
+            relpath = data["relative-path"]
+            H = read_hif(
+                join(dirname(path), relpath), nodetype=nodetype, edgetype=edgetype
+            )
+            collection[name] = H
+        return collection
+    except KeyError:
+        raise XGIError("Data collection is in the wrong format!")

--- a/xgi/readwrite/json.py
+++ b/xgi/readwrite/json.py
@@ -3,6 +3,7 @@
 import json
 from collections import defaultdict
 from os.path import dirname, join
+from warnings import warn
 
 from ..convert import from_hypergraph_dict, to_hypergraph_dict
 from ..core import Hypergraph, SimplicialComplex
@@ -36,6 +37,7 @@ def write_json(H, path, collection_name=""):
         to strings, e.g., node IDs "2" and 2.
 
     """
+    warn("This function is deprecated in favor of the 'write_hif()' function")
     if collection_name:
         collection_name += "_"
 
@@ -101,6 +103,7 @@ def read_json(path, nodetype=None, edgetype=None):
         If the JSON is not in a format that can be loaded.
 
     """
+    warn("This function is deprecated in favor of the 'read_hif()' function")
     with open(path) as file:
         jsondata = json.loads(file.read())
 

--- a/xgi/readwrite/xgi_data.py
+++ b/xgi/readwrite/xgi_data.py
@@ -168,6 +168,7 @@ def _request_from_xgi_data(
     if "incidences" in jsondata:
         H = from_hif_dict(H, nodetype=nodetype, edgetype=edgetype)
         return cut_to_order(H, order=max_order)
+    
     if "type" in jsondata and jsondata["type"] != "collection":
         collection = {}
         for name, data in jsondata["datasets"].items():

--- a/xgi/readwrite/xgi_data.py
+++ b/xgi/readwrite/xgi_data.py
@@ -109,8 +109,6 @@ def download_xgi_data(dataset, path="", collection_name=""):
         The name of the collection of data (if any). If `dataset` is not
         a collection, this argument is unused.
     """
-    from ..readwrite import write_json
-
     index_url = "https://raw.githubusercontent.com/xgi-org/xgi-data/main/index.json"
     index_data = request_json_from_url(index_url)
 

--- a/xgi/readwrite/xgi_data.py
+++ b/xgi/readwrite/xgi_data.py
@@ -166,7 +166,9 @@ def _request_from_xgi_data(
 
     if "incidences" in jsondata:
         H = from_hif_dict(H, nodetype=nodetype, edgetype=edgetype)
-        return cut_to_order(H, order=max_order)
+        if max_order:
+            H = cut_to_order(H, order=max_order)
+        return H
 
     if "type" in jsondata and jsondata["type"] == "collection":
         collection = {}

--- a/xgi/readwrite/xgi_data.py
+++ b/xgi/readwrite/xgi_data.py
@@ -6,7 +6,6 @@ from warnings import warn
 from ..convert import cut_to_order, from_hif_dict, from_hypergraph_dict
 from ..exception import XGIError
 from ..utils import request_json_from_url, request_json_from_url_cached
-from .hif import write_hif, write_hif_collection
 
 __all__ = ["load_xgi_data", "download_xgi_data"]
 
@@ -59,9 +58,9 @@ def load_xgi_data(
     if read:
         cfp = join(path, dataset + ".json")
         if exists(cfp):
-            from ..readwrite import read_hif
+            from ..readwrite import read_json
 
-            return read_hif(cfp, nodetype=nodetype, edgetype=edgetype)
+            return read_json(cfp, nodetype=nodetype, edgetype=edgetype)
         else:
             warn(
                 f"No local copy was found at {cfp}. The data is requested "
@@ -109,6 +108,8 @@ def download_xgi_data(dataset, path="", collection_name=""):
         The name of the collection of data (if any). If `dataset` is not
         a collection, this argument is unused.
     """
+    from ..readwrite import write_json
+
     index_url = "https://raw.githubusercontent.com/xgi-org/xgi-data/main/index.json"
     index_data = request_json_from_url(index_url)
 
@@ -124,10 +125,10 @@ def download_xgi_data(dataset, path="", collection_name=""):
         url, nodetype=None, edgetype=None, max_order=None, cache=True
     )
     if isinstance(H, dict):
-        write_hif_collection(H, path, collection_name=collection_name)
+        write_json(H, path, collection_name=collection_name)
     else:
         filename = join(path, key + ".json")
-        write_hif(H, filename)
+        write_json(H, filename)
 
 
 def _request_from_xgi_data(
@@ -166,8 +167,8 @@ def _request_from_xgi_data(
     if "incidences" in jsondata:
         H = from_hif_dict(H, nodetype=nodetype, edgetype=edgetype)
         return cut_to_order(H, order=max_order)
-    
-    if "type" in jsondata and jsondata["type"] != "collection":
+
+    if "type" in jsondata and jsondata["type"] == "collection":
         collection = {}
         for name, data in jsondata["datasets"].items():
             relpath = data["relative-path"]

--- a/xgi/stats/nodestats.py
+++ b/xgi/stats/nodestats.py
@@ -265,7 +265,7 @@ def local_clustering_coefficient(net, bunch):
     >>> import xgi
     >>> H = xgi.random_hypergraph(3, [1, 1])
     >>> H.nodes.local_clustering_coefficient.asdict()
-    {0: 1.0, 1: 1.0, 2: 1.0}
+    {0: 0.3333333333333333, 1: 0.3333333333333333, 2: 0.3333333333333333}
 
     """
     cc = xgi.local_clustering_coefficient(net)


### PR DESCRIPTION
In preparation for converting XGI-DATA to the HIF standard, this PR does the following:
* Moves the internals of `write_hif` and `read_hif` to the `convert` module as `to_hif_dict` and `from_hif_dict`.
* Modifies `load_xgi_data` to (1) allow HIF format as an input and (2) download/read files in HIF format
* Adds a warning in the `write_json` and `read_json` functions notifying users that they are now deprecated.