### PR TITLE
Add metadata attributes to ashist() for improved plotting

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -3,9 +3,6 @@ on:
   push:
     branches:
       - main
-  pull_request:
-    branches:
-      - main
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -3,6 +3,9 @@ on:
   push:
     branches:
       - main
+  pull_request:
+    branches:
+      - main
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -38,6 +38,3 @@ jobs:
           alert-threshold: '200%'
           comment-on-alert: false
           fail-on-alert: true
-          output-metric: 'mean'
-          metric-unit: 'ms'
-          metric-scale: '1000'

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -38,3 +38,6 @@ jobs:
           alert-threshold: '200%'
           comment-on-alert: false
           fail-on-alert: true
+          output-metric: 'mean'
+          metric-unit: 'ms'
+          metric-scale: '1000'

--- a/benchmarks/core.py
+++ b/benchmarks/core.py
@@ -4,6 +4,21 @@ rounds = 10
 fname = "benchmarks/email-enron.json"
 
 
+# Below is an example so I can better understand the control flow
+def test_simple_benchmark(benchmark):
+    """A simple benchmark to test the workflow."""
+    def setup():
+        # No setup needed for this simple test
+        return (), {}
+
+    def run_benchmark():
+        x = 0
+        for i in range(1000):
+            x += i
+        return x
+
+    benchmark.pedantic(run_benchmark, setup=setup, rounds=rounds)
+
 def test_construct_from_edgelist(benchmark):
     def setup():
         H = xgi.read_hif(fname)

--- a/benchmarks/core.py
+++ b/benchmarks/core.py
@@ -4,21 +4,6 @@ rounds = 10
 fname = "benchmarks/email-enron.json"
 
 
-# Below is an example so I can better understand the control flow
-def test_simple_benchmark(benchmark):
-    """A simple benchmark to test the workflow."""
-    def setup():
-        # No setup needed for this simple test
-        return (), {}
-
-    def run_benchmark():
-        x = 0
-        for i in range(1000):
-            x += i
-        return x
-
-    benchmark.pedantic(run_benchmark, setup=setup, rounds=rounds)
-
 def test_construct_from_edgelist(benchmark):
     def setup():
         H = xgi.read_hif(fname)

--- a/tests/stats/test_core_stats_functions.py
+++ b/tests/stats/test_core_stats_functions.py
@@ -575,6 +575,68 @@ def test_issue_468():
     assert H.edges.size.ashist().equals(df)
 
 
+
+
+def test_ashist_attrs_exist():
+    """Test that ashist returns DataFrame with expected attributes."""
+    H = xgi.sunflower(3, 1, 20)
+    df = H.edges.size.ashist()
+    
+    # Check that all expected attributes exist
+    assert 'xlabel' in df.attrs
+    assert 'ylabel' in df.attrs
+    assert 'title' in df.attrs
+
+
+def test_ashist_density_labels():
+    """Test that ylabel changes based on density parameter."""
+    H = xgi.sunflower(3, 1, 20)
+    
+    # Test default (density=False)
+    df_count = H.edges.size.ashist(density=False)
+    assert df_count.attrs['ylabel'] == 'Count'
+    
+    # Test with density=True
+    df_density = H.edges.size.ashist(density=True)
+    assert df_density.attrs['ylabel'] == 'Probability'
+
+
+def test_ashist_original_functionality():
+    """Test that adding attributes doesn't break original functionality."""
+    H = xgi.sunflower(3, 1, 20)
+    df = H.edges.size.ashist()
+    
+    # Original test case should still pass
+    expected_df = pd.DataFrame([[20.0, 3]], columns=["bin_center", "value"])
+    assert df.equals(expected_df)  # Original functionality
+    
+    # And should have attributes
+    assert 'xlabel' in df.attrs
+
+
+
+def test_ashist_single_unique_value():
+    """Test ashist when there is only one unique value and multiple bins."""
+    H = xgi.Hypergraph()
+    H.add_nodes_from(range(5))
+    # All edges have the same size
+    H.add_edges_from([[0, 1], [2, 3], [4, 0]])
+    
+    # The edge sizes will all be 2
+    df = H.edges.size.ashist(bins=10)
+    
+    # Since there's only one unique value, bins should be set to 1
+    assert len(df) == 1  # Only one bin should be present
+    assert df['bin_center'].iloc[0] == 2  # The bin center should be the unique value
+    assert df['value'].iloc[0] == 3  # There are three edges of size 2
+
+    # Check that attributes are present
+    assert 'xlabel' in df.attrs
+    assert 'ylabel' in df.attrs
+    assert 'title' in df.attrs
+
+
+
 ### Attribute statistics
 
 

--- a/xgi/stats/__init__.py
+++ b/xgi/stats/__init__.py
@@ -162,6 +162,7 @@ class IDStat:
         """
         return pd.Series(self._val, name=self.name)
 
+
     def ashist(self, bins=10, bin_edges=False, density=False, log_binning=False):
         """Return the distribution of a numpy array.
 
@@ -180,7 +181,6 @@ class IDStat:
             Whether to bin the values with log-sized bins.
             By default, False.
 
-
         Returns
         -------
         Pandas DataFrame
@@ -188,6 +188,11 @@ class IDStat:
             where "value" is a count or a probability. If `bin_edges`
             is True, outputs two additional columns, `bin_lo` and `bin_hi`,
             which outputs the left and right bin edges respectively.
+
+            The DataFrame includes the following attributes:
+                - attrs['xlabel']: Label for x-axis
+            - attrs['ylabel']: 'Count' or 'Probability' based on density parameter
+            - attrs['title']: Plot title
 
         Notes
         -----
@@ -199,7 +204,19 @@ class IDStat:
         if isinstance(bins, int) and len(set(self.aslist())) == 1:
             bins = 1
 
-        return hist(self.asnumpy(), bins, bin_edges, density, log_binning)
+        # My modifications below
+
+        # Get the histogram Dataframe
+        df = hist(self.asnumpy(), bins, bin_edges, density, log_binning)
+
+        # Add metadata attributes
+        df.attrs["xlabel"] = "Value"
+        df.attrs["ylabel"] = "Probability" if density else "Count"
+        df.attrs["title"] = "Histogram"
+
+        return df
+
+
 
     def max(self):
         """The maximum value of this stat."""


### PR DESCRIPTION
### Description

This PR adds metadata attributes (`xlabel`, `ylabel`, and `title`) to the `ashist()` function's output DataFrame. These attributes simplify the plotting process by providing standardized labels, reducing the need for manual labeling, and ensuring consistency across different plots.

### Changes Made

- Added `df.attrs["xlabel"] = "Value"`
- Added `df.attrs["ylabel"] = "Probability" if density else "Count"`
- Added `df.attrs["title"] = "Histogram"`

### Testing

- Added unit tests to verify the presence and correctness of the metadata attributes.
- Ensured that existing functionality remains unaffected.

### Related Issues

Closes #<606>