### PR TITLE
Integrate optional plotting capabilities into ashist()

### DIFF
--- a/tests/stats/test_core_stats_functions.py
+++ b/tests/stats/test_core_stats_functions.py
@@ -630,6 +630,78 @@ def test_ashist_original_functionality():
     assert "xlabel" in df.attrs
 
 
+def test_ashist_plotting_basic():
+    """Test basic plotting functionality."""
+    H = xgi.sunflower(3, 1, 20)
+
+    # Test that plot=False still returns correct DataFrame
+    df_no_plot = H.edges.size.ashist(plot=False)
+    expected_df = pd.DataFrame([[20.0, 3]], columns=["bin_center", "value"])
+    assert df_no_plot.equals(expected_df)
+
+    # Test that plot=True returns correct DataFrame
+    df_with_plot = H.edges.size.ashist(plot=True)
+    assert df_with_plot.equals(expected_df)
+
+
+def test_ashist_plot_types():
+    """Test different plot types."""
+    H = xgi.sunflower(3, 1, 20)
+
+    # Test valid plot types
+    for plot_type in ["bar", "line", "step"]:
+        df = H.edges.size.ashist(plot=plot_type)
+        expected_df = pd.DataFrame([[20.0, 3]], columns=["bin_center", "value"])
+        assert df.equals(expected_df)
+
+
+def test_ashist_plot_kwargs():
+    """Test plot kwargs functionality."""
+    H = xgi.sunflower(3, 1, 20)
+
+    # Test with valid kwargs
+    df = H.edges.size.ashist(plot="bar", plot_kwargs={"color": "red", "alpha": 0.5})
+    expected_df = pd.DataFrame([[20.0, 3]], columns=["bin_center", "value"])
+    assert df.equals(expected_df)
+
+
+def test_ashist_plot_errors():
+    """Test error handling in plotting."""
+    H = xgi.sunflower(3, 1, 20)
+
+    # Test invalid plot type
+    with pytest.raises(ValueError, match="Unknown plot type"):
+        H.edges.size.ashist(plot="invalid_type")
+
+    # Test with valid matplotlib parameters
+    df = H.edges.size.ashist(
+        plot="bar",
+        plot_kwargs={"color": "red", "alpha": 0.5},  # Known valid parameters
+    )
+    assert isinstance(df, pd.DataFrame)
+
+
+def test_ashist_density_plotting():
+    """Test plotting with density parameter."""
+    H = xgi.sunflower(3, 1, 20)
+
+    # Test with density=True
+    df = H.edges.size.ashist(plot=True, density=True)
+    # Note: actual values will be different with density=True
+    assert "bin_center" in df.columns
+    assert "value" in df.columns
+
+
+def test_ashist_bin_edges_plotting():
+    """Test plotting with bin_edges parameter."""
+    H = xgi.sunflower(3, 1, 20)
+
+    # Test with bin_edges=True
+    df = H.edges.size.ashist(plot=True, bin_edges=True)
+    assert "bin_lo" in df.columns
+    assert "bin_hi" in df.columns
+
+
 def test_ashist_single_unique_value():
     """Test ashist when there is only one unique value and multiple bins."""
     H = xgi.Hypergraph()

--- a/tests/stats/test_core_stats_functions.py
+++ b/tests/stats/test_core_stats_functions.py
@@ -649,7 +649,7 @@ def test_ashist_plot_types():
     H = xgi.sunflower(3, 1, 20)
 
     # Test valid plot types
-    for plot_type in ["bar", "line", "step"]:
+    for plot_type in ["bar", "line", "scatter", "step"]:
         df = H.edges.size.ashist(plot=plot_type)
         expected_df = pd.DataFrame([[20.0, 3]], columns=["bin_center", "value"])
         assert df.equals(expected_df)
@@ -700,6 +700,27 @@ def test_ashist_bin_edges_plotting():
     df = H.edges.size.ashist(plot=True, bin_edges=True)
     assert "bin_lo" in df.columns
     assert "bin_hi" in df.columns
+
+
+def test_plot_hist_helper():
+    """Test the _plot_hist helper directly."""
+    import matplotlib.pyplot as plt
+
+    from xgi.stats import _plot_hist
+
+    H = xgi.sunflower(3, 1, 20)
+    df = H.edges.size.ashist(bin_edges=True)
+
+    for plot_type in ["bar", "line", "scatter", "step"]:
+        ax = _plot_hist(df, plot_type=plot_type, bin_edges=True)
+        assert isinstance(ax, plt.Axes)
+        assert ax.get_xlabel() == df.attrs["xlabel"]
+        assert ax.get_ylabel() == df.attrs["ylabel"]
+        assert ax.get_title() == df.attrs["title"]
+        plt.close(ax.figure)
+
+    with pytest.raises(ValueError, match="Unknown plot type"):
+        _plot_hist(df, plot_type="invalid_type")
 
 
 def test_ashist_single_unique_value():

--- a/xgi/stats/__init__.py
+++ b/xgi/stats/__init__.py
@@ -194,8 +194,8 @@ class IDStat:
             By default, False.
         plot : bool or str
             If True (or ``"bar"``), plot the histogram with matplotlib as a bar
-            chart. Can also be ``"line"`` or ``"step"`` to choose the plot type.
-            By default, False.
+            chart. Can also be ``"line"``, ``"scatter"``, or ``"step"`` to choose
+            the plot type. By default, False.
         plot_kwargs : dict, optional
             Additional keyword arguments passed to the matplotlib plotting
             function. By default, None.
@@ -213,6 +213,10 @@ class IDStat:
                 - attrs['ylabel']: 'Count' or 'Probability' based on density parameter
                 - attrs['title']: Plot title
 
+        See Also
+        --------
+        ~xgi.stats._plot_hist
+
         Notes
         -----
         Originally from https://github.com/jkbren/networks-and-dataviz
@@ -220,8 +224,9 @@ class IDStat:
         Examples
         --------
         >>> import xgi
-        >>> H = xgi.Hypergraph([[1, 2], [2, 3, 4], [1, 2, 3]])
+        >>> H = xgi.Hypergraph([[1, 2, 3], [3, 4], [1, 3, 6]])
         >>> df = H.nodes.degree.ashist(plot="bar", plot_kwargs={"color": "red"})
+
         """
 
         # if there is one unique value and more than one bin is specified,
@@ -239,39 +244,8 @@ class IDStat:
 
         # Optionally plot the histogram
         if plot:
-            try:
-                import matplotlib.pyplot as plt
-            except ImportError:
-                raise ImportError("Matplotlib is required for plotting.")
-
-            plot_kwargs = plot_kwargs or {}
             plot_type = "bar" if plot is True else plot
-            if plot_type not in ("bar", "line", "step"):
-                raise ValueError(
-                    f"Unknown plot type {plot_type!r}; "
-                    "expected one of 'bar', 'line', or 'step'."
-                )
-
-            fig, ax = plt.subplots()
-
-            if plot_type == "bar":
-                ax.bar(df["bin_center"], df["value"], **plot_kwargs)
-            elif plot_type == "line":
-                ax.plot(df["bin_center"], df["value"], **plot_kwargs)
-            else:  # "step"
-                ax.step(df["bin_center"], df["value"], where="mid", **plot_kwargs)
-
-            ax.set_xlabel(df.attrs["xlabel"])
-            ax.set_ylabel(df.attrs["ylabel"])
-            ax.set_title(df.attrs["title"])
-
-            # Draw the bin edges if they are available
-            if bin_edges:
-                for _, row in df.iterrows():
-                    ax.axvline(row["bin_lo"], color="gray", linestyle="--", alpha=0.5)
-                    ax.axvline(row["bin_hi"], color="gray", linestyle="--", alpha=0.5)
-
-            plt.show()
+            _plot_hist(df, plot_type, plot_kwargs=plot_kwargs, bin_edges=bin_edges)
 
         return df
 
@@ -709,6 +683,70 @@ _dispatch_data = {
         "multistatclass": MultiDiEdgeStat,
     },
 }
+
+
+def _plot_hist(df, plot_type="bar", plot_kwargs=None, bin_edges=False):
+    """Plot a histogram DataFrame produced by :meth:`IDStat.ashist`.
+
+    Parameters
+    ----------
+    df : pandas.DataFrame
+        Output of :func:`~xgi.utils.hist`, with "bin_center" and "value" columns
+        and "xlabel", "ylabel", and "title" entries in ``df.attrs``.
+    plot_type : str
+        The type of plot to draw, one of "bar", "line", "scatter", or "step".
+        By default, "bar".
+    plot_kwargs : dict, optional
+        Additional keyword arguments passed to the matplotlib plotting function.
+        By default, None.
+    bin_edges : bool
+        Whether to draw vertical dashed lines at the bin edges. Requires the
+        "bin_lo" and "bin_hi" columns in `df`. By default, False.
+
+    Returns
+    -------
+    matplotlib.axes.Axes
+        The axes the histogram was drawn on.
+
+    Raises
+    ------
+    ValueError
+        If `plot_type` is not one of "bar", "line", "scatter", or "step".
+
+    """
+    import matplotlib.pyplot as plt
+
+    valid_types = ("bar", "line", "scatter", "step")
+    if plot_type not in valid_types:
+        raise ValueError(
+            f"Unknown plot type {plot_type!r}; expected one of {valid_types}."
+        )
+
+    plot_kwargs = plot_kwargs or {}
+    _, ax = plt.subplots()
+
+    if plot_type == "bar":
+        ax.bar(df["bin_center"], df["value"], **plot_kwargs)
+    elif plot_type == "line":
+        ax.plot(df["bin_center"], df["value"], **plot_kwargs)
+    elif plot_type == "scatter":
+        ax.scatter(df["bin_center"], df["value"], **plot_kwargs)
+    else:  # "step"
+        ax.step(df["bin_center"], df["value"], where="mid", **plot_kwargs)
+
+    ax.set_xlabel(df.attrs["xlabel"])
+    ax.set_ylabel(df.attrs["ylabel"])
+    ax.set_title(df.attrs["title"])
+
+    # Draw the bin edges if they are available
+    if bin_edges:
+        for _, row in df.iterrows():
+            ax.axvline(row["bin_lo"], color="gray", linestyle="--", alpha=0.5)
+            ax.axvline(row["bin_hi"], color="gray", linestyle="--", alpha=0.5)
+
+    plt.show()
+
+    return ax
 
 
 def dispatch_stat(kind, net, view, name):

--- a/xgi/stats/__init__.py
+++ b/xgi/stats/__init__.py
@@ -167,8 +167,16 @@ class IDStat:
 
         return pd.Series(self._val, name=self.name)
 
-    def ashist(self, bins=10, bin_edges=False, density=False, log_binning=False):
-        """Return the distribution of a numpy array.
+    def ashist(
+        self,
+        bins=10,
+        bin_edges=False,
+        density=False,
+        log_binning=False,
+        plot=False,
+        plot_kwargs=None,
+    ):
+        """Return the distribution of a numpy array and optionally plot it.
 
         Parameters
         ----------
@@ -184,6 +192,13 @@ class IDStat:
         log_binning : bool
             Whether to bin the values with log-sized bins.
             By default, False.
+        plot : bool or str
+            If True (or ``"bar"``), plot the histogram with matplotlib as a bar
+            chart. Can also be ``"line"`` or ``"step"`` to choose the plot type.
+            By default, False.
+        plot_kwargs : dict, optional
+            Additional keyword arguments passed to the matplotlib plotting
+            function. By default, None.
 
         Returns
         -------
@@ -195,20 +210,24 @@ class IDStat:
 
             The DataFrame includes the following attributes:
                 - attrs['xlabel']: Label for x-axis
-            - attrs['ylabel']: 'Count' or 'Probability' based on density parameter
-            - attrs['title']: Plot title
+                - attrs['ylabel']: 'Count' or 'Probability' based on density parameter
+                - attrs['title']: Plot title
 
         Notes
         -----
         Originally from https://github.com/jkbren/networks-and-dataviz
+
+        Examples
+        --------
+        >>> import xgi
+        >>> H = xgi.Hypergraph([[1, 2], [2, 3, 4], [1, 2, 3]])
+        >>> df = H.nodes.degree.ashist(plot="bar", plot_kwargs={"color": "red"})
         """
 
         # if there is one unique value and more than one bin is specified,
         # sets the number of bins to 1.
         if isinstance(bins, int) and len(set(self.aslist())) == 1:
             bins = 1
-
-        # My modifications below
 
         # Get the histogram Dataframe
         df = hist(self.asnumpy(), bins, bin_edges, density, log_binning)
@@ -217,6 +236,42 @@ class IDStat:
         df.attrs["xlabel"] = "Value"
         df.attrs["ylabel"] = "Probability" if density else "Count"
         df.attrs["title"] = "Histogram"
+
+        # Optionally plot the histogram
+        if plot:
+            try:
+                import matplotlib.pyplot as plt
+            except ImportError:
+                raise ImportError("Matplotlib is required for plotting.")
+
+            plot_kwargs = plot_kwargs or {}
+            plot_type = "bar" if plot is True else plot
+            if plot_type not in ("bar", "line", "step"):
+                raise ValueError(
+                    f"Unknown plot type {plot_type!r}; "
+                    "expected one of 'bar', 'line', or 'step'."
+                )
+
+            fig, ax = plt.subplots()
+
+            if plot_type == "bar":
+                ax.bar(df["bin_center"], df["value"], **plot_kwargs)
+            elif plot_type == "line":
+                ax.plot(df["bin_center"], df["value"], **plot_kwargs)
+            else:  # "step"
+                ax.step(df["bin_center"], df["value"], where="mid", **plot_kwargs)
+
+            ax.set_xlabel(df.attrs["xlabel"])
+            ax.set_ylabel(df.attrs["ylabel"])
+            ax.set_title(df.attrs["title"])
+
+            # Draw the bin edges if they are available
+            if bin_edges:
+                for _, row in df.iterrows():
+                    ax.axvline(row["bin_lo"], color="gray", linestyle="--", alpha=0.5)
+                    ax.axvline(row["bin_hi"], color="gray", linestyle="--", alpha=0.5)
+
+            plt.show()
 
         return df
 


### PR DESCRIPTION
### Description

This PR integrates optional plotting capabilities directly into the `ashist()` function. Users can now generate plots (`'bar'`, `'line'`, or `'step'`) by setting the `plot` parameter to `True` and customize plot appearance using `plot_kwargs`.

### Changes Made

- Added `plot` and `plot_kwargs` parameters to the `ashist()` function.
- Implemented plotting logic using `matplotlib.pyplot` based on the specified plot type.
- Automatically sets axis labels and plot titles using metadata attributes.
- Adds vertical lines for bin edges if `bin_edges` is `True`.

### Testing

- Added unit tests to validate different plot types and `plot_kwargs`.
- Ensured that invalid plot types raise appropriate errors.
- Verified interaction with existing parameters like `density` and `bin_edges`.

### Related Issues

Closes #<606>