### PR TITLE
Fix/normalized hypergraph laplacian

### DIFF
--- a/tests/linalg/test_matrix.py
+++ b/tests/linalg/test_matrix.py
@@ -608,18 +608,21 @@ def test_normalized_hypergraph_laplacian():
     assert isinstance(L2, np.ndarray)
     assert np.all(L1.toarray() == L2)
 
+    # Eigenvalues are all non-negative
     evals = eigh(L2, eigvals_only=True)
     negative_evals = list(filter(lambda e: e < 0, evals))
     assert (not negative_evals) or (np.allclose(negative_evals, 0))
 
     L3, d = xgi.normalized_hypergraph_laplacian(H, index=True)
     assert d == {0: 1, 1: 2, 2: 3, 3: 4, 4: 5, 5: 6, 6: 7, 7: 8}
+    assert np.allclose(L3.toarray(), L2)
 
     # sqrt(d) is eigenvector with eigenvalue 0
     sqrt_d = np.array([np.sqrt(d) for d in H.nodes.degree.aslist()])
     assert np.allclose(L3 @ sqrt_d, 0)
 
-    true_L = np.array(
+    # Exact Laplacian calculation
+    true_L3 = np.array(
         [
             [0.666667, -0.333333, -0.333333, -0.0, -0.0, -0.0, -0.0, -0.0],
             [-0.333333, 0.666667, -0.333333, -0.0, -0.0, -0.0, -0.0, -0.0],
@@ -631,9 +634,11 @@ def test_normalized_hypergraph_laplacian():
             [-0.0, -0.0, -0.0, -0.0, -0.0, -0.235702, -0.333333, 0.666667],
         ]
     )
-    assert np.allclose(true_L, L2)
+    assert np.allclose(true_L3, L3.toarray())
 
-    el_mwe = [
+
+def test_fix_647():
+    el = [
         {1, 2, 3},
         {1, 4, 5},
         {1, 6, 7, 8},
@@ -641,22 +646,25 @@ def test_normalized_hypergraph_laplacian():
         {1, 13, 14, 15, 16},
         {4, 17, 18},
     ]
-    H_mwe = xgi.Hypergraph(el_mwe)
-    L_mwe = xgi.normalized_hypergraph_laplacian(H_mwe, sparse=False)
-    evals_mwe = eigvalsh(L_mwe)
+    H = xgi.Hypergraph(el)
+    L = xgi.normalized_hypergraph_laplacian(H, sparse=False)
+
+    # Eigenvalues non-negative
+    evals_mwe = eigvalsh(L)
     assert np.all(evals_mwe >= 0)
 
     # Weights error handling
-    ## Default
-    L_mwe_wtd = xgi.normalized_hypergraph_laplacian(H_mwe, weighted=True, sparse=False)
-    assert np.allclose(L_mwe, L_mwe_wtd)
+    ## Default value when "weight" attribute unavailable
+    L_wtd = xgi.normalized_hypergraph_laplacian(H, weighted=True, sparse=False)
+    assert np.allclose(L, L_wtd)
 
     ## Uniform weight
-    H_mwe.set_edge_attributes(2, name="weight")
-    L_mwe_wtd_uni = xgi.normalized_hypergraph_laplacian(
-        H_mwe, weighted=True, sparse=False
+    H_wtd = H.copy()
+    H_wtd.set_edge_attributes(2, name="weight")
+    L_wtd_uniform = xgi.normalized_hypergraph_laplacian(
+        H_wtd, weighted=True, sparse=False
     )
-    assert np.allclose(2 * L_mwe_wtd - np.eye(H_mwe.num_nodes), L_mwe_wtd_uni)
+    assert np.allclose(2 * L_wtd - np.eye(H_wtd.num_nodes), L_wtd_uniform)
 
 
 def test_empty_order(edgelist6):

--- a/tests/linalg/test_matrix.py
+++ b/tests/linalg/test_matrix.py
@@ -1,6 +1,6 @@
 import numpy as np
 import pytest
-from scipy.linalg import eigh
+from scipy.linalg import eigh, eigvalsh
 from scipy.sparse import csr_array
 from scipy.sparse.linalg import norm as spnorm
 
@@ -615,6 +615,24 @@ def test_normalized_hypergraph_laplacian():
     L3, d = xgi.normalized_hypergraph_laplacian(H, index=True)
     assert d == {0: 1, 1: 2, 2: 3, 3: 4, 4: 5, 5: 6, 6: 7, 7: 8}
 
+    # sqrt(d) is eigenvector with eigenvalue 0
+    sqrt_d = np.array([np.sqrt(d) for d in H.nodes.degree.aslist()])
+    assert np.allclose(L3 @ sqrt_d, 0)
+
+    true_L = np.array(
+        [
+            [0.666667, -0.333333, -0.333333, -0.0, -0.0, -0.0, -0.0, -0.0],
+            [-0.333333, 0.666667, -0.333333, -0.0, -0.0, -0.0, -0.0, -0.0],
+            [-0.333333, -0.333333, 0.666667, -0.0, -0.0, -0.0, -0.0, -0.0],
+            [-0.0, -0.0, -0.0, 0.0, -0.0, -0.0, -0.0, -0.0],
+            [-0.0, -0.0, -0.0, -0.0, 0.5, -0.353553, -0.0, -0.0],
+            [-0.0, -0.0, -0.0, -0.0, -0.353553, 0.583333, -0.235702, -0.235702],
+            [-0.0, -0.0, -0.0, -0.0, -0.0, -0.235702, 0.666667, -0.333333],
+            [-0.0, -0.0, -0.0, -0.0, -0.0, -0.235702, -0.333333, 0.666667],
+        ]
+    )
+    assert np.allclose(true_L, L2)
+
     el_mwe = [
         {1, 2, 3},
         {1, 4, 5},
@@ -625,7 +643,7 @@ def test_normalized_hypergraph_laplacian():
     ]
     H = xgi.Hypergraph(el_mwe)
     L = xgi.normalized_hypergraph_laplacian(H, sparse=False)
-    evals = eigh(L, eigvals_only=True)
+    evals = eigvalsh(L)
     assert np.all(evals >= 0)
 
     # Weights error handling

--- a/tests/linalg/test_matrix.py
+++ b/tests/linalg/test_matrix.py
@@ -610,7 +610,7 @@ def test_normalized_hypergraph_laplacian():
 
     evals = eigh(L2, eigvals_only=True)
     negative_evals = list(filter(lambda e: e < 0, evals))
-    assert (not negative_evals) | (np.allclose(negative_evals, 0))
+    assert (not negative_evals) or (np.allclose(negative_evals, 0))
 
     L3, d = xgi.normalized_hypergraph_laplacian(H, index=True)
     assert d == {0: 1, 1: 2, 2: 3, 3: 4, 4: 5, 5: 6, 6: 7, 7: 8}
@@ -623,9 +623,9 @@ def test_normalized_hypergraph_laplacian():
         {1, 13, 14, 15, 16},
         {4, 17, 18},
     ]
-    H = xgi.Hypergraph(E)
+    H = xgi.Hypergraph(el_mwe)
     L = xgi.normalized_hypergraph_laplacian(H, sparse=False)
-    evals, evecs = eigh(L)
+    evals = eigh(L, eigvals_only=True)
     assert np.all(evals >= 0)
 
     # Weights error handling

--- a/tests/linalg/test_matrix.py
+++ b/tests/linalg/test_matrix.py
@@ -641,31 +641,22 @@ def test_normalized_hypergraph_laplacian():
         {1, 13, 14, 15, 16},
         {4, 17, 18},
     ]
-    H = xgi.Hypergraph(el_mwe)
-    L = xgi.normalized_hypergraph_laplacian(H, sparse=False)
-    evals = eigvalsh(L)
-    assert np.all(evals >= 0)
+    H_mwe = xgi.Hypergraph(el_mwe)
+    L_mwe = xgi.normalized_hypergraph_laplacian(H_mwe, sparse=False)
+    evals_mwe = eigvalsh(L_mwe)
+    assert np.all(evals_mwe >= 0)
 
     # Weights error handling
-    ## Type errors
-    with pytest.raises(XGIError):
-        xgi.normalized_hypergraph_laplacian(H, weights=1)
-    with pytest.raises(XGIError):
-        xgi.normalized_hypergraph_laplacian(H, weights="1")
+    ## Default
+    L_mwe_wtd = xgi.normalized_hypergraph_laplacian(H_mwe, weighted=True, sparse=False)
+    assert np.allclose(L_mwe, L_mwe_wtd)
 
-    ## Length errors
-    with pytest.raises(XGIError):  # too few
-        xgi.normalized_hypergraph_laplacian(H, weights=[1])
-    with pytest.raises(XGIError):  # too many
-        xgi.normalized_hypergraph_laplacian(
-            H, weights=[1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1]
-        )
-
-    ## Value errors
-    with pytest.raises(XGIError):  # zeros
-        xgi.normalized_hypergraph_laplacian(H, weights=[0, 1, 1, 1])
-    with pytest.raises(XGIError):  # negatives
-        xgi.normalized_hypergraph_laplacian(H, weights=[-1, 1, 1, 1])
+    ## Uniform weight
+    H_mwe.set_edge_attributes(2, name="weight")
+    L_mwe_wtd_uni = xgi.normalized_hypergraph_laplacian(
+        H_mwe, weighted=True, sparse=False
+    )
+    assert np.allclose(2 * L_mwe_wtd - np.eye(H_mwe.num_nodes), L_mwe_wtd_uni)
 
 
 def test_empty_order(edgelist6):

--- a/tests/linalg/test_matrix.py
+++ b/tests/linalg/test_matrix.py
@@ -1,8 +1,8 @@
 import numpy as np
 import pytest
+from scipy.linalg import eigh
 from scipy.sparse import csr_array
 from scipy.sparse.linalg import norm as spnorm
-from scipy.linalg import eigh
 
 import xgi
 from xgi.exception import XGIError
@@ -615,6 +615,19 @@ def test_normalized_hypergraph_laplacian():
     L3, d = xgi.normalized_hypergraph_laplacian(H, index=True)
     assert d == {0: 1, 1: 2, 2: 3, 3: 4, 4: 5, 5: 6, 6: 7, 7: 8}
 
+    el_mwe = [
+        {1, 2, 3},
+        {1, 4, 5},
+        {1, 6, 7, 8},
+        {4, 9, 10, 11, 12},
+        {1, 13, 14, 15, 16},
+        {4, 17, 18},
+    ]
+    H = xgi.Hypergraph(E)
+    L = xgi.normalized_hypergraph_laplacian(H, sparse=False)
+    evals, evecs = eigh(L)
+    assert np.all(evals >= 0)
+
     # Weights error handling
     ## Type errors
     with pytest.raises(XGIError):
@@ -626,7 +639,9 @@ def test_normalized_hypergraph_laplacian():
     with pytest.raises(XGIError):  # too few
         xgi.normalized_hypergraph_laplacian(H, weights=[1])
     with pytest.raises(XGIError):  # too many
-        xgi.normalized_hypergraph_laplacian(H, weights=[1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1])
+        xgi.normalized_hypergraph_laplacian(
+            H, weights=[1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1]
+        )
 
     ## Value errors
     with pytest.raises(XGIError):  # zeros

--- a/xgi/linalg/laplacian_matrix.py
+++ b/xgi/linalg/laplacian_matrix.py
@@ -217,7 +217,10 @@ def normalized_hypergraph_laplacian(H, weights=None, sparse=True, index=False):
         If there are isolated nodes.
 
     XGIError
-        If there are negative edge weights.
+        If there are an incorrect number of edge weights.
+
+    XGIError
+        If there are non-positive edge weights.
 
     References
     ----------

--- a/xgi/linalg/laplacian_matrix.py
+++ b/xgi/linalg/laplacian_matrix.py
@@ -47,7 +47,7 @@ array([[1, 0, 0],
 from warnings import warn
 
 import numpy as np
-from scipy.sparse import csr_array, diags, identity
+from scipy.sparse import csr_array, diags_array, eye_array
 
 from ..exception import XGIError
 from .hypergraph_matrix import (
@@ -236,31 +236,23 @@ def normalized_hypergraph_laplacian(H, weighted=False, sparse=True, index=False)
 
     Dv = degree_matrix(H)
     De = np.sum(incidence, axis=0)
+
     if weighted:
         weights = [H.edges[edge_idx].get("weight", 1) for edge_idx in H.edges]
-    
+    else:
+        weights = [1] * H.num_edges
 
     if sparse:
         Dv_invsqrt = diags_array(np.power(Dv, -0.5), format="csr")
-        De_inv = diags(1 / De)
-
-        if weighted:
-            W = diags_array(weights, format="csr")
-        else:
-            W = eye_array(H.num_edges, format="csr")
-
+        De_inv = diags_array(1 / De, format="csr")
+        W = diags_array(weights, format="csr")
         eye = eye_array(H.num_nodes, format="csr")
     else:
         Dv_invsqrt = np.diag(np.power(Dv, -0.5))
         De_inv = np.diag(1 / De)
-
-        if weighted:
-            W = np.diag(weights)
-        else:
-            W = np.eye(H.num_edges)
-
+        W = np.diag(weights)
         eye = np.eye(H.num_nodes)
 
-    L = eye - Dv_invsqrt @ incidence @ W @ De_inv @ incidence.T @ Dv_invsqrt
+    L = eye - Dv_invsqrt @ incidence @ W @ De_inv @ np.tranpose(incidence) @ Dv_invsqrt
 
     return (L, rowdict) if index else L

--- a/xgi/linalg/laplacian_matrix.py
+++ b/xgi/linalg/laplacian_matrix.py
@@ -106,7 +106,7 @@ def laplacian(H, order=1, sparse=False, rescale_per_node=False, index=False):
         return (L, {}) if index else L
 
     if sparse:
-        K = csr_array(diags_array(degree_matrix(H, order=order)))
+        K = diags_array(degree_matrix(H, order=order), format="csr")
     else:
         K = np.diag(degree_matrix(H, order=order))
 

--- a/xgi/linalg/laplacian_matrix.py
+++ b/xgi/linalg/laplacian_matrix.py
@@ -270,12 +270,8 @@ def normalized_hypergraph_laplacian(H, weights=None, sparse=True, index=False):
     else:
         Dv_invsqrt = np.diag(np.power(Dv, -0.5))
 
-        De_inv = np.diag(list(
-            map(
-                lambda x: 1/x,
-                np.sum(H_, axis=0)
-            )
-        ))
+        De = np.sum(H_, axis=0)
+        De_inv = np.diag(1 / De)
 
         if weights is not None:
             W = np.diag(weights)

--- a/xgi/linalg/laplacian_matrix.py
+++ b/xgi/linalg/laplacian_matrix.py
@@ -52,7 +52,6 @@ from scipy.sparse import csr_array, diags_array, eye_array
 from ..exception import XGIError
 from .hypergraph_matrix import (
     adjacency_matrix,
-    clique_motif_matrix,
     degree_matrix,
     incidence_matrix,
 )
@@ -107,7 +106,7 @@ def laplacian(H, order=1, sparse=False, rescale_per_node=False, index=False):
         return (L, {}) if index else L
 
     if sparse:
-        K = csr_array(diags(degree_matrix(H, order=order)))
+        K = csr_array(diags_array(degree_matrix(H, order=order)))
     else:
         K = np.diag(degree_matrix(H, order=order))
 

--- a/xgi/linalg/laplacian_matrix.py
+++ b/xgi/linalg/laplacian_matrix.py
@@ -195,8 +195,8 @@ def normalized_hypergraph_laplacian(H, weighted=False, sparse=True, index=False)
     ----------
     H : Hypergraph
         Hypergraph
-    weights : list of floats or None, optional
-        Hyperedge weights, by default None (every edge weighted as 1).
+    weighted : bool, optional
+        whether or not to use hyperedge weightr, by default False (every edge weighted as 1).
     sparse : bool, optional
         whether or not the laplacian is sparse, by default True
     index : bool, optional
@@ -215,12 +215,6 @@ def normalized_hypergraph_laplacian(H, weighted=False, sparse=True, index=False)
     ------
     XGIError
         If there are isolated nodes.
-
-    XGIError
-        If there are an incorrect number of edge weights.
-
-    XGIError
-        If there are non-positive edge weights.
 
     References
     ----------


### PR DESCRIPTION
# Summary
Rewrote `normalized_hypergraph_laplacian` implementation to match reference implementation. Fixes #647 .

# Description
Rewrote the matrix calculations in `normalized_hypergraph_laplacian` to match the implementation referenced here: https://github.com/xgi-org/xgi/issues/647#issuecomment-2612087221. Also adds a `weighted` Boolean parameter to allow for differentially weighting edges in the Laplacian calculation, drawn from each edge's "weight" attribute if available (default to 1 if unavailable).

# Concerns
I have only added barebone unit tests for the _effect_ of edge weights (only on their acceptable definition). I am unsure how or what the expected behavior would be for non-uniform edge weights.

# Other
~~Currently only supports strictly positive weights - a weight of zero would cause some issues with rank. That said, an edge weight of 0 could be interpreted as the subgraph with that edge removed and could be a nice way to handle zero weights in the future?~~ Deprecated with latest commit [573eaad](https://github.com/xgi-org/xgi/pull/648/commits/573eaad7c41708e9c0e640c613d3746588147014).