### PR TITLE
Split the GitHub actions for the tutorials and source code

### DIFF
--- a/.github/workflows/test-code.yml
+++ b/.github/workflows/test-code.yml
@@ -1,0 +1,39 @@
+name: test
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  pytest:
+    runs-on: ${{ matrix.os }}-latest
+    strategy:
+      matrix:
+        os: [ubuntu, macos, windows]
+        python-version: ['3.10', '3.11', '3.12', '3.13']
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v5
+      with:
+        python-version: ${{ matrix.python-version }}
+
+    - name: Install packages
+      run: |
+        pip install --upgrade pip
+        pip install .[test,docs]
+        pip list
+
+    - name: Test XGI
+      run: |
+        # run test suite
+        cd tests/
+        pytest --color=yes
+        # run doctests
+        cd ../xgi/
+        pytest --color=yes

--- a/.github/workflows/test-tutorials.yml
+++ b/.github/workflows/test-tutorials.yml
@@ -11,16 +11,13 @@ on:
 jobs:
   tutorials:
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        python-version: ['3.10', '3.11', '3.12', '3.13']
     steps:
     - uses: actions/checkout@v4
 
-    - name: Set up Python ${{ matrix.python-version }}
+    - name: Set up Python 3.13
       uses: actions/setup-python@v5
       with:
-        python-version: ${{ matrix.python-version }}
+        python-version: "3.13"
 
     - name: Install packages
       run: |
@@ -95,8 +92,9 @@ jobs:
         # run pytest ONLY on the tutorials
         cd tutorials
 
-        cd case_studies
-        pytest --color=yes
+        # removed this to speed up the tests
+        # cd case_studies
+        # pytest --color=yes
 
         cd ../focus
         pytest --color=yes
@@ -105,33 +103,4 @@ jobs:
         pytest --color=yes
 
         cd ../in_depth
-        pytest --color=yes
-
-  pytest:
-    runs-on: ${{ matrix.os }}-latest
-    strategy:
-      matrix:
-        os: [ubuntu, macos, windows]
-        python-version: ['3.10', '3.11', '3.12', '3.13']
-    steps:
-    - uses: actions/checkout@v4
-
-    - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v5
-      with:
-        python-version: ${{ matrix.python-version }}
-
-    - name: Install packages
-      run: |
-        pip install --upgrade pip
-        pip install .[test,docs]
-        pip list
-
-    - name: Test XGI
-      run: |
-        # run test suite
-        cd tests/
-        pytest --color=yes
-        # run doctests
-        cd ../xgi/
         pytest --color=yes


### PR DESCRIPTION
More recently, it seems like the GitHub action for verifying that our tuto notebooks run is taking 30+ minutes. That seems insane! In response to this, I have done the following:
* split the "test" GitHub Action into `test-code.yml` and `test-tutorials.yml`
* Removed the grid of Python versions and only test on the latest Python version
* Removed the testing of the case studies