### PR TITLE
Add adjacency tensor function

### DIFF
--- a/docs/source/api/linalg/xgi.linalg.hypergraph_matrix.rst
+++ b/docs/source/api/linalg/xgi.linalg.hypergraph_matrix.rst
@@ -8,6 +8,7 @@
    .. rubric:: Functions
    
    .. autofunction:: adjacency_matrix
+   .. autofunction:: adjacency_tensor
    .. autofunction:: clique_motif_matrix
    .. autofunction:: degree_matrix
    .. autofunction:: incidence_matrix

--- a/tests/linalg/test_matrix.py
+++ b/tests/linalg/test_matrix.py
@@ -758,7 +758,6 @@ def test_empty():
     assert xgi.hodge_laplacian(H).shape == (0, 0)
 
 
-
 def test_adjacency_tensor(edgelist1):
     el1 = edgelist1
     H1 = xgi.Hypergraph(el1)

--- a/tests/linalg/test_matrix.py
+++ b/tests/linalg/test_matrix.py
@@ -790,3 +790,14 @@ def test_adjacency_tensor(edgelist1):
     assert A12[node_dict1[7], node_dict1[6], node_dict1[8]] == 1
     assert A12[node_dict1[8], node_dict1[6], node_dict1[7]] == 1
     assert A12[node_dict1[8], node_dict1[7], node_dict1[6]] == 1
+
+    # normalization
+    A11_norm = xgi.adjacency_tensor(H1, order=1, normalized=True)
+    assert np.allclose(A11_norm, A11)
+
+    A12_norm = xgi.adjacency_tensor(H1, order=2, normalized=True)
+    assert np.allclose(A12_norm, A12 / 2)
+
+    A13 = xgi.adjacency_tensor(H1, order=3)
+    A13_norm = xgi.adjacency_tensor(H1, order=3, normalized=True)
+    assert np.allclose(A13_norm, A13 / 6)

--- a/tests/linalg/test_matrix.py
+++ b/tests/linalg/test_matrix.py
@@ -756,3 +756,38 @@ def test_empty():
     assert xgi.boundary_matrix(H).shape == (0, 0)
 
     assert xgi.hodge_laplacian(H).shape == (0, 0)
+
+
+
+def test_adjacency_tensor(edgelist1):
+    el1 = edgelist1
+    H1 = xgi.Hypergraph(el1)
+
+    A11, node_dict = xgi.adjacency_tensor(H1, order=1, index=True)
+    node_dict1 = {k: v for v, k in node_dict.items()}
+
+    assert type(A11) == np.ndarray
+    assert A11.shape == (8, 8)
+    assert A11.sum() == 2
+    assert list(np.unique(A11)) == [0, 1]
+    assert np.all(A11 == xgi.adjacency_matrix(H1, order=1, sparse=False))
+
+    A12 = xgi.adjacency_tensor(H1, order=2)
+    assert type(A12) == np.ndarray
+    assert A12.shape == (8, 8, 8)
+    assert A12.sum() == 12
+    assert list(np.unique(A12)) == [0, 1]
+
+    assert A12[node_dict1[1], node_dict1[2], node_dict1[3]] == 1
+    assert A12[node_dict1[1], node_dict1[3], node_dict1[2]] == 1
+    assert A12[node_dict1[2], node_dict1[3], node_dict1[1]] == 1
+    assert A12[node_dict1[2], node_dict1[1], node_dict1[3]] == 1
+    assert A12[node_dict1[3], node_dict1[1], node_dict1[2]] == 1
+    assert A12[node_dict1[3], node_dict1[2], node_dict1[1]] == 1
+
+    assert A12[node_dict1[6], node_dict1[7], node_dict1[8]] == 1
+    assert A12[node_dict1[6], node_dict1[8], node_dict1[7]] == 1
+    assert A12[node_dict1[7], node_dict1[8], node_dict1[6]] == 1
+    assert A12[node_dict1[7], node_dict1[6], node_dict1[8]] == 1
+    assert A12[node_dict1[8], node_dict1[6], node_dict1[7]] == 1
+    assert A12[node_dict1[8], node_dict1[7], node_dict1[6]] == 1

--- a/xgi/linalg/hypergraph_matrix.py
+++ b/xgi/linalg/hypergraph_matrix.py
@@ -333,19 +333,16 @@ def adjacency_tensor(H, order, index=False):
     # find nodes participating in each hyperedge
     hyperedges = H.edges.filterby("order", order).members()
 
-    map_node2index = {v: k for (k, v) in rowdict.items()}
-    hyperedges_node_ids = [
-        {map_node2index[node] for node in edge} for edge in hyperedges
-    ]
-
+    nodedict = {v: k for (k, v) in rowdict.items()}
     N = H.num_nodes
 
     # initialize adjacency tensor
     B = np.zeros((N,) * (order + 1), dtype=int)
 
     # populate adjacency tensor
-    for edge in hyperedges_node_ids:
-        for node_idx in permutations(edge, order + 1):
+    for edge in hyperedges:
+        edge_node_ids = [nodedict[node] for node in edge]
+        for node_idx in permutations(edge_node_ids, order + 1):
             B[node_idx] = 1
 
     return (B, rowdict) if index else B

--- a/xgi/linalg/hypergraph_matrix.py
+++ b/xgi/linalg/hypergraph_matrix.py
@@ -44,6 +44,7 @@ array([[1, 0, 0],
 
 """
 
+from itertools import permutations
 from warnings import catch_warnings, warn
 
 import numpy as np
@@ -55,6 +56,7 @@ __all__ = [
     "intersection_profile",
     "degree_matrix",
     "clique_motif_matrix",
+    "adjacency_tensor",
 ]
 
 
@@ -318,7 +320,7 @@ def adjacency_tensor(H, order, index=False):
         Adjacency tensor
     """
 
-    I, rowdict, _ = xgi.incidence_matrix(H, order=order, sparse=False, index=True) 
+    I, rowdict, _ = incidence_matrix(H, order=order, sparse=False, index=True) 
 
     if I.shape == (0, 0):
         if not rowdict:
@@ -341,7 +343,7 @@ def adjacency_tensor(H, order, index=False):
     
     # populate adjacency tensor
     for edge in hyperedges_node_ids:
-        for node_idx in itertools.permutations(edge, order+1):
+        for node_idx in permutations(edge, order+1):
             B[node_idx] = 1
 
     return (B, rowdict) if index else B

--- a/xgi/linalg/hypergraph_matrix.py
+++ b/xgi/linalg/hypergraph_matrix.py
@@ -45,6 +45,7 @@ array([[1, 0, 0],
 """
 
 from itertools import permutations
+from math import factorial
 from warnings import catch_warnings, warn
 
 import numpy as np
@@ -298,7 +299,7 @@ def clique_motif_matrix(H, sparse=True, index=False):
     return (W, rowdict) if index else W
 
 
-def adjacency_tensor(H, order, index=False):
+def adjacency_tensor(H, order, normalized=False, index=False):
     """
     Compute the order-d adjacency tensor of a hypergraph from its incidence matrix.
 
@@ -318,6 +319,12 @@ def adjacency_tensor(H, order, index=False):
     -------
     B : np.ndarray
         Adjacency tensor
+
+    References
+    ----------
+    Galuppi, F., Mulas, R., & Venturello, L. (2023).   
+    "Spectral theory of weighted hypergraphs via tensors"  
+    Linear and Multilinear Algebra, 71(3), 317-347.  
     """
 
     I, rowdict, _ = incidence_matrix(H, order=order, sparse=False, index=True)
@@ -344,5 +351,8 @@ def adjacency_tensor(H, order, index=False):
         edge_node_ids = [nodedict[node] for node in edge]
         for node_idx in permutations(edge_node_ids, order + 1):
             B[node_idx] = 1
+
+    if normalized:
+        B /= factorial(order)
 
     return (B, rowdict) if index else B

--- a/xgi/linalg/hypergraph_matrix.py
+++ b/xgi/linalg/hypergraph_matrix.py
@@ -318,7 +318,15 @@ def adjacency_tensor(H, order, index=False):
         Adjacency tensor
     """
 
-    I, rowdict, _ = xgi.incidence_matrix(H, order=order, sparse=False, index=True)  # (N_nodes x N_hyperedges)
+    I, rowdict, _ = xgi.incidence_matrix(H, order=order, sparse=False, index=True) 
+
+    if I.shape == (0, 0):
+        if not rowdict:
+            B = np.empty((0,) * (order + 1))
+        if not coldict:
+            shape = (H.num_nodes, ) * (order + 1)
+            B = np.zeros(shape, dtype=int)
+        return (B, {}) if index else B
     
     # find nodes participating in each hyperedge
     hyperedges = H.edges.filterby("order", order).members()

--- a/xgi/linalg/hypergraph_matrix.py
+++ b/xgi/linalg/hypergraph_matrix.py
@@ -302,7 +302,7 @@ def adjacency_tensor(H, order, index=False):
     """
     Compute the order-d adjacency tensor of a hypergraph from its incidence matrix.
 
-    The order-d adjacency tensor B is defined as B[i1, i2, ..., id] = 1 if there exists 
+    The order-d adjacency tensor B is defined as B[i1, i2, ..., id] = 1 if there exists
     a hyperedge containing nodes (i1, i2, ..., id), and 0 otherwise.
 
     Parameters
@@ -320,30 +320,32 @@ def adjacency_tensor(H, order, index=False):
         Adjacency tensor
     """
 
-    I, rowdict, _ = incidence_matrix(H, order=order, sparse=False, index=True) 
+    I, rowdict, _ = incidence_matrix(H, order=order, sparse=False, index=True)
 
     if I.shape == (0, 0):
         if not rowdict:
             B = np.empty((0,) * (order + 1))
         if not coldict:
-            shape = (H.num_nodes, ) * (order + 1)
+            shape = (H.num_nodes,) * (order + 1)
             B = np.zeros(shape, dtype=int)
         return (B, {}) if index else B
-    
+
     # find nodes participating in each hyperedge
     hyperedges = H.edges.filterby("order", order).members()
 
-    map_node2index = {v: k for (k,v) in rowdict.items()}
-    hyperedges_node_ids = [{map_node2index[node] for node in edge} for edge in hyperedges]
-    
+    map_node2index = {v: k for (k, v) in rowdict.items()}
+    hyperedges_node_ids = [
+        {map_node2index[node] for node in edge} for edge in hyperedges
+    ]
+
     N = H.num_nodes
-    
+
     # initialize adjacency tensor
-    B = np.zeros((N,) * (order+1), dtype=int)
-    
+    B = np.zeros((N,) * (order + 1), dtype=int)
+
     # populate adjacency tensor
     for edge in hyperedges_node_ids:
-        for node_idx in permutations(edge, order+1):
+        for node_idx in permutations(edge, order + 1):
             B[node_idx] = 1
 
     return (B, rowdict) if index else B

--- a/xgi/linalg/hypergraph_matrix.py
+++ b/xgi/linalg/hypergraph_matrix.py
@@ -344,7 +344,8 @@ def adjacency_tensor(H, order, normalized=False, index=False):
     N = H.num_nodes
 
     # initialize adjacency tensor
-    B = np.zeros((N,) * (order + 1), dtype=int)
+    dtype = float if normalized else int
+    B = np.zeros((N,) * (order + 1), dtype=dtype)
 
     # populate adjacency tensor
     for edge in hyperedges:

--- a/xgi/linalg/hypergraph_matrix.py
+++ b/xgi/linalg/hypergraph_matrix.py
@@ -327,7 +327,7 @@ def adjacency_tensor(H, order, normalized=False, index=False):
     Linear and Multilinear Algebra, 71(3), 317-347.  
     """
 
-    I, rowdict, _ = incidence_matrix(H, order=order, sparse=False, index=True)
+    I, rowdict, coldict = incidence_matrix(H, order=order, sparse=False, index=True)
 
     if I.shape == (0, 0):
         if not rowdict:


### PR DESCRIPTION
The function does not have a `sparse` option like the other matrix functions, because `scipy.sparse` has no implementation for sparse tensors (only 2d arrays). Potential candidate for later: the [sparse](https://sparse.pydata.org/en/stable/construct.html) library, but it does not have the equivalent of the `csr_array` that we usually use. 