### PR TITLE
Document node label sizing in draw function

### DIFF
--- a/docs/source/api/drawing/xgi.drawing.draw.rst
+++ b/docs/source/api/drawing/xgi.drawing.draw.rst
@@ -6,6 +6,17 @@ xgi.drawing.draw
 .. automodule:: xgi.drawing.draw
    
    .. rubric:: Functions
+
+.. note::
+   
+   **Node Label Sizing**: The :func:`draw` function does not currently support 
+   customizing the size of node labels. Node labels are drawn with default sizing.
+   
+   If you need to customize node label properties (including size), you can draw 
+   the hypergraph elements separately using :func:`draw_nodes` and then use 
+   :func:`draw_node_labels` with custom matplotlib text properties. Alternatively, 
+   you can use matplotlib's text manipulation functions directly on the drawn labels.
+
    
    .. autofunction:: draw
    .. autofunction:: draw_bipartite


### PR DESCRIPTION
Added documentation note clarifying that the draw() function does not currently support customizing node label sizes. Provided alternative approaches for users who need label customization.

Fixes #500