### PR TITLE
Feature/compressed io

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,6 +49,7 @@ dependencies = [
     "requests>=2.0",
     "matplotlib>=3.4",
     "seaborn>=0.10",
+    "xopen>=2.0.2",
 ]
 
 [project.urls]

--- a/xgi/readwrite/bipartite.py
+++ b/xgi/readwrite/bipartite.py
@@ -1,5 +1,7 @@
 """Read from and write to bipartite formats."""
 
+from xopen import xopen
+
 from ..exception import XGIError
 from ..generators import empty_hypergraph
 
@@ -111,7 +113,7 @@ def read_bipartite_edgelist(
     >>> # H = xgi.read_bipartite_edgelist("test.csv", delimiter=",")
 
     """
-    with open(path, "rb") as file:
+    with xopen(path, "rb") as file:
         lines = (
             line if isinstance(line, str) else line.decode(encoding) for line in file
         )

--- a/xgi/readwrite/edgelist.py
+++ b/xgi/readwrite/edgelist.py
@@ -1,5 +1,7 @@
 """Read from and write to edgelists."""
 
+from xopen import xopen
+
 from ..generators import empty_hypergraph
 
 __all__ = [
@@ -98,7 +100,7 @@ def read_edgelist(
     >>> # H = xgi.read_edgelist("test.csv", delimiter=",")
 
     """
-    with open(path, "rb") as file:
+    with xopen(path, "rb") as file:
         lines = (
             line if isinstance(line, str) else line.decode(encoding) for line in file
         )

--- a/xgi/readwrite/hif.py
+++ b/xgi/readwrite/hif.py
@@ -8,6 +8,8 @@ import json
 from collections import defaultdict
 from os.path import dirname, join
 
+from xopen import xopen
+
 from ..convert import from_hif_dict, to_hif_dict
 from ..exception import XGIError
 
@@ -99,7 +101,7 @@ def read_hif(path, nodetype=None, edgetype=None):
     A Hypergraph, SimplicialComplex, or DiHypergraph object
         The loaded network
     """
-    with open(path) as file:
+    with xopen(path) as file:
         data = json.loads(file.read())
 
     return from_hif_dict(data, nodetype=nodetype, edgetype=edgetype)


### PR DESCRIPTION
Draft PR to add support for compressed data I/O.

# Relevant issues

Closes #681 .

# Description

Adds support for reading and writing supported data formats with `.gz`, `.bz2`, `.xz`, and `.zst` compressions.

# Checklist

- [x] Add `xopen` dependency and ensure compatibility with all other dependencies.
- [x] Replace read functions' `open` statements with `xopen.xopen` 
- [x] Test reading functionality is preserved for uncompressed files
- [x] Test reading functionality now accepts compressed files
- [x] Replace write functions' `open` statements with `xopen.xopen`
- [x] Propagate added `kwargs` from interface to compression `kwargs`
- [x] Test writing functionality is preserved for uncompressed files
- [x] Test writing functionality now accepts compressed files

# Notes

The custom JSON format the predated the HIF standard is marked as deprecated and I was not planning on updating its functionality with the rest here; this is despite the deprecation currently implemented as a warning and not an error. 

I used Big Pickle via OpenCode Zen to implement the writing functionality and its tests.
I double checked the work myself; I don't know if I _love_ the style choices made with the helper, but everything worked as expected and was clear so I left it.
This is my first time using AI tools to contribute to public codebases, I am more than happy to redo it by hand if there are reservations!