### PR TITLE
Clean up exception hierarchy for v1.0

### DIFF
--- a/tests/algorithms/test_assortativity.py
+++ b/tests/algorithms/test_assortativity.py
@@ -72,9 +72,9 @@ def test_degree_assortativity(edgelist1, edgelist5):
         xgi.degree_assortativity(H)
 
     # test wrong kind
-    with pytest.raises(XGIError):
+    with pytest.raises(ValueError):
         xgi.degree_assortativity(H1, kind="no-idea")
-    with pytest.raises(XGIError):
+    with pytest.raises(ValueError):
         xgi.degree_assortativity(H1, kind="no-idea", exact=True)
 
 
@@ -88,7 +88,7 @@ def test_choose_degrees(edgelist1, edgelist6):
         _choose_degrees(e, k)
 
     # invalid choice function
-    with pytest.raises(XGIError):
+    with pytest.raises(ValueError):
         e = H1.edges.members(0)
         _choose_degrees(e, k, "test")
 

--- a/tests/generators/test_lattice.py
+++ b/tests/generators/test_lattice.py
@@ -1,7 +1,6 @@
 import pytest
 
 import xgi
-from xgi.exception import XGIError
 
 
 def test_ring_lattice():
@@ -27,5 +26,5 @@ def test_ring_lattice():
         xgi.ring_lattice(5, 2, 3, 0)
 
     # k < 0 test
-    with pytest.raises(XGIError):
+    with pytest.raises(ValueError):
         xgi.ring_lattice(5, 2, -1, 0)

--- a/tests/generators/test_simple.py
+++ b/tests/generators/test_simple.py
@@ -1,7 +1,6 @@
 import pytest
 
 import xgi
-from xgi.exception import XGIError
 
 
 def test_star_clique():
@@ -21,7 +20,7 @@ def test_star_clique():
 
 
 def test_sunflower():
-    with pytest.raises(XGIError):
+    with pytest.raises(ValueError):
         H = xgi.sunflower(3, 4, 2)
 
     H = xgi.sunflower(3, 1, 5)

--- a/tests/generators/test_uniform.py
+++ b/tests/generators/test_uniform.py
@@ -3,7 +3,6 @@ import pytest
 from scipy.special import comb
 
 import xgi
-from xgi.exception import XGIError
 
 
 def test_uniform_configuration_model_hypergraph():
@@ -23,7 +22,7 @@ def test_uniform_configuration_model_hypergraph():
 
 def test_uniform_HSBM():
     # sum of sizes != n
-    with pytest.raises(XGIError):
+    with pytest.raises(ValueError):
         m = 2
         n = 10
         sizes = [4, 5]
@@ -31,7 +30,7 @@ def test_uniform_HSBM():
         xgi.uniform_HSBM(n, m, p, sizes)
 
     # non-square p
-    with pytest.raises(XGIError):
+    with pytest.raises(ValueError):
         m = 2
         n = 10
         sizes = [4, 6]
@@ -39,7 +38,7 @@ def test_uniform_HSBM():
         xgi.uniform_HSBM(n, m, p, sizes)
 
     # length of sizes and length of p don't match
-    with pytest.raises(XGIError):
+    with pytest.raises(ValueError):
         m = 2
         n = 10
         sizes = [4, 5, 1]
@@ -48,7 +47,7 @@ def test_uniform_HSBM():
 
     # dim of p is not m
     # non-square p
-    with pytest.raises(XGIError):
+    with pytest.raises(ValueError):
         m = 3
         n = 10
         sizes = [4, 6]
@@ -56,7 +55,7 @@ def test_uniform_HSBM():
         xgi.uniform_HSBM(n, m, p, sizes)
 
     # test p < 0
-    with pytest.raises(XGIError):
+    with pytest.raises(ValueError):
         m = 2
         n = 10
         sizes = [4, 6]
@@ -64,7 +63,7 @@ def test_uniform_HSBM():
         xgi.uniform_HSBM(n, m, p, sizes)
 
     # test p > 1
-    with pytest.raises(XGIError):
+    with pytest.raises(ValueError):
         m = 2
         n = 10
         sizes = [4, 6]
@@ -88,7 +87,7 @@ def test_uniform_HSBM():
 
 def test_uniform_HPPM():
     # rho < 0
-    with pytest.raises(XGIError):
+    with pytest.raises(ValueError):
         m = 2
         n = 10
         rho = -0.1
@@ -97,7 +96,7 @@ def test_uniform_HPPM():
         xgi.uniform_HPPM(n, m, k, epsilon, rho)
 
     # rho > 1
-    with pytest.raises(XGIError):
+    with pytest.raises(ValueError):
         m = 2
         n = 10
         rho = 1.1
@@ -106,7 +105,7 @@ def test_uniform_HPPM():
         xgi.uniform_HPPM(n, m, k, epsilon, rho)
 
     # k < 0
-    with pytest.raises(XGIError):
+    with pytest.raises(ValueError):
         m = 2
         n = 10
         rho = 0.5
@@ -115,7 +114,7 @@ def test_uniform_HPPM():
         xgi.uniform_HPPM(n, m, k, epsilon, rho)
 
     # epsilon < 0
-    with pytest.raises(XGIError):
+    with pytest.raises(ValueError):
         m = 2
         n = 10
         rho = 0.5
@@ -124,7 +123,7 @@ def test_uniform_HPPM():
         xgi.uniform_HPPM(n, m, k, epsilon)
 
     # epsilon < 0
-    with pytest.raises(XGIError):
+    with pytest.raises(ValueError):
         m = 2
         n = 10
         rho = 0.5
@@ -178,21 +177,21 @@ def test_uniform_erdos_renyi_hypergraph():
     assert H1.edges.members(dtype=dict) == H2.edges.members(dtype=dict)
 
     # test p < 0
-    with pytest.raises(XGIError):
+    with pytest.raises(ValueError):
         m = 2
         n = 10
         p = -0.1
         xgi.uniform_erdos_renyi_hypergraph(n, m, p, p_type="prob")
 
     # test p > 1
-    with pytest.raises(XGIError):
+    with pytest.raises(ValueError):
         m = 2
         n = 10
         p = 1.1
         xgi.uniform_erdos_renyi_hypergraph(n, m, p, p_type="prob")
 
     # test wrong p_type arg
-    with pytest.raises(XGIError):
+    with pytest.raises(ValueError):
         m = 2
         n = 10
         k = 2

--- a/xgi/algorithms/assortativity.py
+++ b/xgi/algorithms/assortativity.py
@@ -137,7 +137,7 @@ def degree_assortativity(H, kind="uniform", exact=False, num_samples=1000):
                 # permutations is so that k1 and k2 have the same variance
             ]
         else:
-            raise XGIError("Invalid type of degree assortativity!")
+            raise ValueError("Invalid type of degree assortativity!")
     else:
         edges = [e for e in H.edges if len(H.edges.members(e)) > 1]
         k1k2 = [
@@ -173,7 +173,7 @@ def _choose_degrees(e, k, kind="uniform"):
 
     Raises
     ------
-    XGIError
+    ValueError
         if invalid assortativity function chosen
 
     See Also
@@ -204,6 +204,6 @@ def _choose_degrees(e, k, kind="uniform"):
             return sorted([k[i] for i in e])[:: len(e) - 1]
 
         else:
-            raise XGIError("Invalid type of degree assortativity!")
+            raise ValueError("Invalid type of degree assortativity!")
     else:
         raise XGIError("Edge must have more than one member!")

--- a/xgi/exception.py
+++ b/xgi/exception.py
@@ -6,7 +6,7 @@ class XGIError(XGIException):
     """Exception for a serious error in XGI"""
 
 
-class IDNotFound(KeyError):
+class IDNotFound(XGIException, KeyError):
     """Raised when a node or edge is not in the hypergraph."""
 
 

--- a/xgi/generators/lattice.py
+++ b/xgi/generators/lattice.py
@@ -7,7 +7,6 @@ hypergraph).
 
 from warnings import warn
 
-from ..exception import XGIError
 
 __all__ = [
     "ring_lattice",
@@ -38,7 +37,7 @@ def ring_lattice(n, d, k, l):
 
     Raises
     ------
-    XGIError
+    ValueError
         If k is negative.
 
     Notes
@@ -50,7 +49,7 @@ def ring_lattice(n, d, k, l):
     from ..core import Hypergraph
 
     if k < 0:
-        raise XGIError("Invalid k value!")
+        raise ValueError("Invalid k value!")
 
     if k < 2:
         warn("This creates a completely disconnected hypergraph!")

--- a/xgi/generators/simple.py
+++ b/xgi/generators/simple.py
@@ -7,7 +7,6 @@ hypergraph).
 
 from itertools import combinations
 
-from ..exception import XGIError
 from .classic import empty_hypergraph
 
 __all__ = [
@@ -96,7 +95,7 @@ def sunflower(l, c, m):
 
     Raises
     ------
-    XGIError
+    ValueError
         If the edge size is smaller than the core.
 
     Returns
@@ -106,7 +105,7 @@ def sunflower(l, c, m):
     from ..core import Hypergraph
 
     if m < c:
-        raise XGIError("m cannot be smaller than c.")
+        raise ValueError("m cannot be smaller than c.")
 
     core_nodes = list(range(c))
 

--- a/xgi/generators/uniform.py
+++ b/xgi/generators/uniform.py
@@ -9,7 +9,6 @@ from functools import reduce
 import numpy as np
 from scipy.special import comb
 
-from ..exception import XGIError
 from ..utils import geometric
 from .classic import complete_hypergraph, empty_hypergraph
 
@@ -135,7 +134,7 @@ def uniform_HSBM(n, m, p, sizes, seed=None):
 
     Raises
     ------
-    XGIError
+    ValueError
         - If the length of sizes and p do not match.
         - If p is not a tensor with every dimension equal
         - If p is not m-dimensional
@@ -167,16 +166,16 @@ def uniform_HSBM(n, m, p, sizes, seed=None):
 
     # Check if dimensions match
     if len(sizes) != np.size(p, axis=0):
-        raise XGIError("'sizes' and 'p' do not match.")
+        raise ValueError("'sizes' and 'p' do not match.")
     if len(np.shape(p)) != m:
-        raise XGIError("The dimension of p does not match m")
+        raise ValueError("The dimension of p does not match m")
     # Check that p has the same length over every dimension.
     if len(set(np.shape(p))) != 1:
-        raise XGIError("'p' must be a square tensor.")
+        raise ValueError("'p' must be a square tensor.")
     if np.max(p) > 1 or np.min(p) < 0:
-        raise XGIError("Entries of 'p' not in [0, 1].")
+        raise ValueError("Entries of 'p' not in [0, 1].")
     if np.sum(sizes) != n:
-        raise XGIError("Sum of sizes does not match n")
+        raise ValueError("Sum of sizes does not match n")
 
     if seed is not None:
         random.seed(seed)
@@ -251,7 +250,7 @@ def uniform_HPPM(n, m, k, epsilon, rho=0.5, seed=None):
 
     Raises
     ------
-    XGIError
+    ValueError
         - If rho is not between 0 and 1
         - If the mean degree is negative.
         - If epsilon is not between 0 and 1
@@ -278,11 +277,11 @@ def uniform_HPPM(n, m, k, epsilon, rho=0.5, seed=None):
     """
 
     if rho < 0 or rho > 1:
-        raise XGIError("The value of rho must be between 0 and 1")
+        raise ValueError("The value of rho must be between 0 and 1")
     if k < 0:
-        raise XGIError("The mean degree must be non-negative")
+        raise ValueError("The mean degree must be non-negative")
     if epsilon < 0 or epsilon > 1:
-        raise XGIError("epsilon must be between 0 and 1")
+        raise ValueError("epsilon must be between 0 and 1")
 
     sizes = [int(rho * n), n - int(rho * n)]
 
@@ -378,10 +377,10 @@ def uniform_erdos_renyi_hypergraph(n, m, p, p_type="prob", multiedges=False, see
     elif p_type == "prob":
         q = p
     else:
-        raise XGIError("Invalid p_type!")
+        raise ValueError("Invalid p_type!")
 
     if q > 1 or q < 0:
-        raise XGIError("Probability not in [0, 1].")
+        raise ValueError("Probability not in [0, 1].")
 
     if q == 1 and not multiedges:
         return complete_hypergraph(n, order=m - 1)

--- a/xgi/stats/__init__.py
+++ b/xgi/stats/__init__.py
@@ -113,8 +113,9 @@ class IDStat:
         ('degree', 'degree(order=3)')
         >>> H.nodes.multi([da, d3]).asdict(transpose=True).keys()
         dict_keys(['degree', 'degree(order=3)'])
-        >>> H.nodes.multi([da, d3]).aspandas().columns
-        Index(['degree', 'degree(order=3)'], dtype='object')
+        >>> cols = H.nodes.multi([da, d3]).aspandas().columns
+        >>> list(cols)
+        ['degree', 'degree(order=3)']
 
         """
         name = f"{self.func.__name__}"


### PR DESCRIPTION
## Summary
- Make `IDNotFound` inherit from both `XGIException` and `KeyError` (was only `KeyError`), so all XGI exceptions are catchable via `XGIException`
- Replace `XGIError` with `ValueError` for input validation errors in generators and assortativity — these are standard Python invalid-argument cases, not domain-specific errors

## Changes
- `xgi/exception.py`: `IDNotFound(KeyError)` → `IDNotFound(XGIException, KeyError)`
- `xgi/generators/uniform.py`, `lattice.py`, `simple.py`: `XGIError` → `ValueError`
- `xgi/algorithms/assortativity.py`: `XGIError` → `ValueError` for invalid input checks
- Corresponding test files updated

## Rationale
For v1.0, the exception hierarchy should be consistent:
- **`XGIException`**: base for all XGI-specific errors, always catchable
- **`ValueError`**: standard Python exception for invalid arguments — users expect this
- **`XGIError`**: reserved for domain-specific hypergraph errors

## Test plan
- [x] All 393 tests pass
- [x] `IDNotFound` is now catchable via both `XGIException` and `KeyError`

🤖 Generated with [Claude Code](https://claude.com/claude-code)