### PR TITLE
feat: make built-in stats discoverable in dir() and IDE autocomplete

### DIFF
--- a/tests/core/test_views.py
+++ b/tests/core/test_views.py
@@ -543,3 +543,54 @@ def test_edge_head(diedgelist2):
 
     with pytest.raises(IDNotFound):
         H.edges.head("test")
+
+
+def test_stat_discoverability():
+    """Built-in stats should be visible in dir() for IDE and tab completion."""
+    H = xgi.Hypergraph([[1, 2, 3], [2, 3, 4]])
+
+    # Node stats should appear in dir()
+    node_dir = dir(H.nodes)
+    assert "degree" in node_dir
+    assert "clustering_coefficient" in node_dir
+    assert "average_neighbor_degree" in node_dir
+
+    # Edge stats should appear in dir()
+    edge_dir = dir(H.edges)
+    assert "order" in edge_dir
+    assert "size" in edge_dir
+
+    # They should still work as before
+    assert H.nodes.degree.asdict() == {1: 1, 2: 2, 3: 2, 4: 1}
+    assert H.edges.order.asdict() == {0: 2, 1: 2}
+
+    # Directed hypergraph stats should also be discoverable
+    DH = xgi.DiHypergraph([[{1, 2}, {3}]])
+    dinode_dir = dir(DH.nodes)
+    assert "degree" in dinode_dir
+    assert "in_degree" in dinode_dir
+    assert "out_degree" in dinode_dir
+
+    diedge_dir = dir(DH.edges)
+    assert "order" in diedge_dir
+    assert "size" in diedge_dir
+    assert "head_order" in diedge_dir
+    assert "tail_size" in diedge_dir
+
+
+def test_stat_caching():
+    """Accessing a stat twice should return the same cached object."""
+    H = xgi.Hypergraph([[1, 2, 3]])
+    stat1 = H.nodes.degree
+    stat2 = H.nodes.degree
+    assert stat1 is stat2
+
+
+def test_custom_stat_still_works():
+    """User-defined stats via @nodestat_func should still work via __getattr__."""
+    @xgi.nodestat_func
+    def my_custom_stat(net, bunch):
+        return {n: 42 for n in bunch}
+
+    H = xgi.Hypergraph([[1, 2]])
+    assert H.nodes.my_custom_stat.asdict() == {1: 42, 2: 42}

--- a/xgi/core/views.py
+++ b/xgi/core/views.py
@@ -13,6 +13,25 @@ from functools import reduce
 from ..exception import IDNotFound, XGIError
 from ..stats import IDStat, dispatch_many_stats, dispatch_stat
 
+
+class _stat_property:
+    """Non-data descriptor that exposes a stat as a class-level attribute.
+
+    Makes built-in stats visible to dir(), tab completion, and IDE autocomplete
+    while preserving the instance-level caching behavior of the stats system.
+    """
+
+    def __init__(self, stat_name):
+        self.stat_name = stat_name
+
+    def __get__(self, obj, objtype=None):
+        if obj is None:
+            return self
+        stat = dispatch_stat(obj._id_kind, obj._net, obj, self.stat_name)
+        obj.__dict__[self.stat_name] = stat
+        return stat
+
+
 __all__ = [
     "NodeView",
     "EdgeView",
@@ -561,6 +580,21 @@ class NodeView(IDView):
 
     _id_kind = "node"
 
+    attrs = _stat_property("attrs")
+    degree = _stat_property("degree")
+    average_neighbor_degree = _stat_property("average_neighbor_degree")
+    clustering_coefficient = _stat_property("clustering_coefficient")
+    local_clustering_coefficient = _stat_property("local_clustering_coefficient")
+    two_node_clustering_coefficient = _stat_property("two_node_clustering_coefficient")
+    clique_eigenvector_centrality = _stat_property("clique_eigenvector_centrality")
+    h_eigenvector_centrality = _stat_property("h_eigenvector_centrality")
+    z_eigenvector_centrality = _stat_property("z_eigenvector_centrality")
+    node_edge_centrality = _stat_property("node_edge_centrality")
+    katz_centrality = _stat_property("katz_centrality")
+    local_simplicial_fraction = _stat_property("local_simplicial_fraction")
+    local_edit_simpliciality = _stat_property("local_edit_simpliciality")
+    local_face_edit_simpliciality = _stat_property("local_face_edit_simpliciality")
+
     def __init__(self, H, bunch=None):
         if H is None:
             super().__init__(None, bunch)
@@ -657,6 +691,11 @@ class EdgeView(IDView):
     """
 
     _id_kind = "edge"
+
+    attrs = _stat_property("attrs")
+    order = _stat_property("order")
+    size = _stat_property("size")
+    node_edge_centrality = _stat_property("node_edge_centrality")
 
     def __init__(self, H, bunch=None):
         if H is None:
@@ -836,6 +875,11 @@ class DiNodeView(IDView):
 
     _id_kind = "dinode"
 
+    attrs = _stat_property("attrs")
+    degree = _stat_property("degree")
+    in_degree = _stat_property("in_degree")
+    out_degree = _stat_property("out_degree")
+
     def __init__(self, H, bunch=None):
         if H is None:
             super().__init__(None, bunch)
@@ -955,6 +999,14 @@ class DiEdgeView(IDView):
     """
 
     _id_kind = "diedge"
+
+    attrs = _stat_property("attrs")
+    order = _stat_property("order")
+    size = _stat_property("size")
+    head_order = _stat_property("head_order")
+    head_size = _stat_property("head_size")
+    tail_order = _stat_property("tail_order")
+    tail_size = _stat_property("tail_size")
 
     def __init__(self, H, bunch=None):
         if H is None:


### PR DESCRIPTION
## Summary
- Built-in stats (e.g. `degree`, `clustering_coefficient`, `order`) are now visible in `dir()`, Jupyter/IPython tab completion, and IDE autocomplete on `NodeView`, `EdgeView`, `DiNodeView`, and `DiEdgeView`.
- Adds a lightweight `_stat_property` non-data descriptor that delegates to the existing `dispatch_stat` system and preserves instance-level caching.
- `__getattr__` remains as fallback for user-defined stats registered via `@nodestat_func`.

## Motivation
The stats system is XGI's most powerful feature, but it was invisible to tooling. All stats were accessed via `__getattr__`, which doesn't show up in `dir()`, tab completion, or IDE autocomplete. Users had to already know the stats existed to use them.

See also #700 for the companion PR that adds `.pyi` type stubs for static analysis tools (Pylance, PyCharm, mypy).

## Test plan
- [x] `test_stat_discoverability` — verifies stats appear in `dir()` for all four view classes
- [x] `test_stat_caching` — verifies instance-level caching still works
- [x] `test_custom_stat_still_works` — verifies `@nodestat_func` decorator still works via `__getattr__` fallback
- [x] Full test suite passes (395 passed, 6 skipped)

🤖 Generated with [Claude Code](https://claude.com/claude-code)