### PR TITLE
feat: add type stubs for stats on view classes

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -102,6 +102,9 @@ all = ["xgi[benchmark,developer,docs,release,test,tutorial]"]
 [tool.setuptools.packages.find]
 where = ["."]
 
+[tool.setuptools.package-data]
+xgi = ["py.typed", "**/*.pyi"]
+
 [tool.setuptools.dynamic.version]
 attr = "xgi.__version__"
 

--- a/xgi/core/views.pyi
+++ b/xgi/core/views.pyi
@@ -1,0 +1,100 @@
+"""Type stubs for views module.
+
+Declares built-in stats as typed attributes on view classes so that static
+analysis tools (Pylance, PyCharm, mypy) can provide autocomplete and type
+checking for the stats interface.
+"""
+
+from collections.abc import Mapping, Set
+from typing import Any, Callable, Hashable, Iterable, Iterator
+
+from ..stats import DiEdgeStat, DiNodeStat, EdgeStat, NodeStat
+
+class IDView:
+    def __len__(self) -> int: ...
+    def __iter__(self) -> Iterator: ...
+    def __contains__(self, item: Hashable) -> bool: ...
+    def __getitem__(self, item: Hashable) -> dict: ...
+    def __call__(self, *args: Any, **kwargs: Any) -> Any: ...
+    def filterby(self, stat: str, val: Any, mode: str = "eq") -> IDView: ...
+    def filterby_attr(
+        self, attr: str, val: Any, mode: str = "eq", missing: Any = None
+    ) -> IDView: ...
+    @property
+    def ids(self) -> set: ...
+    def neighbors(self, id: Hashable, s: int = 1) -> set: ...
+    def duplicates(self) -> set: ...
+    def lookup(self, query: set) -> set: ...
+    def multi(self, names: Iterable) -> Any: ...
+    @classmethod
+    def from_view(cls, view: IDView, bunch: Any = None) -> IDView: ...
+
+class NodeView(IDView):
+    # Built-in stats
+    attrs: NodeStat
+    degree: NodeStat
+    average_neighbor_degree: NodeStat
+    clustering_coefficient: NodeStat
+    local_clustering_coefficient: NodeStat
+    two_node_clustering_coefficient: NodeStat
+    clique_eigenvector_centrality: NodeStat
+    h_eigenvector_centrality: NodeStat
+    z_eigenvector_centrality: NodeStat
+    node_edge_centrality: NodeStat
+    katz_centrality: NodeStat
+    local_simplicial_fraction: NodeStat
+    local_edit_simpliciality: NodeStat
+    local_face_edit_simpliciality: NodeStat
+
+    def memberships(self, n: Hashable | None = None) -> dict | set: ...
+    def isolates(self, ignore_singletons: bool = False) -> NodeView: ...
+
+class EdgeView(IDView):
+    # Built-in stats
+    attrs: EdgeStat
+    order: EdgeStat
+    size: EdgeStat
+    node_edge_centrality: EdgeStat
+
+    def members(
+        self, e: Hashable | None = None, dtype: type = list
+    ) -> list | dict | set: ...
+    def singletons(self) -> EdgeView: ...
+    def empty(self) -> EdgeView: ...
+    def maximal(self, strict: bool = False) -> EdgeView: ...
+
+class DiNodeView(IDView):
+    # Built-in stats
+    attrs: DiNodeStat
+    degree: DiNodeStat
+    in_degree: DiNodeStat
+    out_degree: DiNodeStat
+
+    def dimemberships(
+        self, n: Hashable | None = None
+    ) -> dict | tuple[set, set]: ...
+    def memberships(self, n: Hashable | None = None) -> dict | set: ...
+    def isolates(self) -> DiNodeView: ...
+
+class DiEdgeView(IDView):
+    # Built-in stats
+    attrs: DiEdgeStat
+    order: DiEdgeStat
+    size: DiEdgeStat
+    head_order: DiEdgeStat
+    head_size: DiEdgeStat
+    tail_order: DiEdgeStat
+    tail_size: DiEdgeStat
+
+    def dimembers(
+        self, e: Hashable | None = None, dtype: type = list
+    ) -> list | dict | tuple[set, set]: ...
+    def members(
+        self, e: Hashable | None = None, dtype: type = list
+    ) -> list | dict | set: ...
+    def head(
+        self, e: Hashable | None = None, dtype: type = list
+    ) -> list | dict | set: ...
+    def tail(
+        self, e: Hashable | None = None, dtype: type = list
+    ) -> list | dict | set: ...


### PR DESCRIPTION
## Summary
- Adds `.pyi` type stub for `xgi.core.views`, declaring built-in stats as typed attributes on `NodeView`, `EdgeView`, `DiNodeView`, and `DiEdgeView`.
- Adds `py.typed` marker (PEP 561) so type checkers recognize XGI as a typed package.
- Configures `pyproject.toml` to include `py.typed` and `*.pyi` files in distributions.

## Motivation
Companion to #699. That PR makes stats discoverable at runtime (`dir()`, Jupyter tab completion). This PR makes them discoverable to static analysis tools (Pylance/VS Code, PyCharm, mypy) which don't execute code.

## Test plan
- [x] Full test suite passes (392 passed, 6 skipped)
- [x] `py.typed` marker is correctly placed and detectable
- [ ] Verify Pylance autocomplete shows stats on `H.nodes.` and `H.edges.` in VS Code

🤖 Generated with [Claude Code](https://claude.com/claude-code)