### PR TITLE
docs: introduce stats earlier, add cheat sheet, link quickstart

### DIFF
--- a/docs/source/api/stats.rst
+++ b/docs/source/api/stats.rst
@@ -4,6 +4,14 @@ stats package
 
 .. automodule:: xgi.stats
 
+.. seealso::
+
+   :doc:`/stats_cheatsheet`
+      Quick reference for output formats, filtering, custom stats, and more.
+
+   :doc:`/api/tutorials/focus_6`
+      Step-by-step tutorial on the stats interface.
+
 .. admonition:: Available statistics
    
    .. rubric:: Hypergraphs and simplicial complexes

--- a/docs/source/api/tutorials/getting_started.rst
+++ b/docs/source/api/tutorials/getting_started.rst
@@ -10,6 +10,7 @@ Getting started
    getting_started_1
    getting_started_2
    getting_started_3
+   getting_started_4
 
 
 

--- a/docs/source/api/tutorials/getting_started_4.nblink
+++ b/docs/source/api/tutorials/getting_started_4.nblink
@@ -1,0 +1,3 @@
+{
+    "path": "../../../../tutorials/getting_started/quickstart.ipynb"
+}

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -13,6 +13,7 @@
 
    installing
    user_guides
+   stats_cheatsheet
    api_reference
    xgi-data
    auto_examples/index

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -13,7 +13,6 @@
 
    installing
    user_guides
-   stats_cheatsheet
    api_reference
    xgi-data
    auto_examples/index

--- a/docs/source/stats_cheatsheet.rst
+++ b/docs/source/stats_cheatsheet.rst
@@ -1,0 +1,187 @@
+Stats Cheat Sheet
+=================
+
+Quick reference for XGI's statistics interface.  For a full tutorial, see
+:doc:`api/tutorials/focus_6`.
+
+Accessing stats
+---------------
+
+Stats are accessed through the ``nodes`` and ``edges`` views:
+
+.. code-block:: python
+
+   import xgi
+   H = xgi.Hypergraph([[1, 2, 3], [2, 3, 4, 5], [3, 4, 5]])
+
+   H.nodes.degree            # NodeStat object
+   H.edges.order              # EdgeStat object
+
+Output formats
+--------------
+
+Every stat object supports the same output methods:
+
+.. list-table::
+   :header-rows: 1
+   :widths: 40 60
+
+   * - Method
+     - Returns
+   * - ``.asdict()``
+     - ``{id: value, ...}``
+   * - ``.aslist()``
+     - ``[value, ...]``
+   * - ``.asnumpy()``
+     - NumPy array
+   * - ``.aspandas()``
+     - Pandas Series
+
+Summary statistics
+------------------
+
+.. list-table::
+   :header-rows: 1
+   :widths: 30 70
+
+   * - Method
+     - Description
+   * - ``.max()``, ``.min()``
+     - Maximum / minimum value
+   * - ``.mean()``, ``.median()``, ``.mode()``
+     - Central tendency
+   * - ``.std()``, ``.var()``
+     - Spread
+   * - ``.sum()``
+     - Total
+   * - ``.moment(order, center)``
+     - Statistical moments
+   * - ``.argmax()``, ``.argmin()``
+     - ID of the max / min
+   * - ``.argsort(reverse)``
+     - IDs sorted by value
+   * - ``.unique(return_counts)``
+     - Unique values
+   * - ``.ashist(bins, density)``
+     - Histogram as DataFrame
+
+Available node statistics
+-------------------------
+
+.. list-table::
+   :header-rows: 1
+   :widths: 40 60
+
+   * - Stat
+     - Example
+   * - ``degree``
+     - ``H.nodes.degree``
+   * - ``average_neighbor_degree``
+     - ``H.nodes.average_neighbor_degree``
+   * - ``clustering_coefficient``
+     - ``H.nodes.clustering_coefficient``
+   * - ``local_clustering_coefficient``
+     - ``H.nodes.local_clustering_coefficient``
+   * - ``two_node_clustering_coefficient``
+     - ``H.nodes.two_node_clustering_coefficient``
+   * - ``clique_eigenvector_centrality``
+     - ``H.nodes.clique_eigenvector_centrality``
+   * - ``h_eigenvector_centrality``
+     - ``H.nodes.h_eigenvector_centrality``
+   * - ``z_eigenvector_centrality``
+     - ``H.nodes.z_eigenvector_centrality``
+   * - ``node_edge_centrality``
+     - ``H.nodes.node_edge_centrality``
+   * - ``katz_centrality``
+     - ``H.nodes.katz_centrality``
+   * - ``attrs``
+     - ``H.nodes.attrs('color')``
+
+Available edge statistics
+-------------------------
+
+.. list-table::
+   :header-rows: 1
+   :widths: 40 60
+
+   * - Stat
+     - Example
+   * - ``order``
+     - ``H.edges.order``
+   * - ``size``
+     - ``H.edges.size``
+   * - ``node_edge_centrality``
+     - ``H.edges.node_edge_centrality``
+   * - ``attrs``
+     - ``H.edges.attrs('weight')``
+
+Directed hypergraph statistics
+------------------------------
+
+**Nodes:** ``degree``, ``in_degree``, ``out_degree``
+
+**Edges:** ``order``, ``size``, ``head_order``, ``head_size``, ``tail_order``, ``tail_size``
+
+Passing arguments
+-----------------
+
+Some stats accept arguments. Call the stat to pass them:
+
+.. code-block:: python
+
+   H.nodes.degree              # all orders
+   H.nodes.degree(order=2)     # only order-2 edges
+   H.edges.order(degree=3)     # only nodes with degree 3
+
+Filtering
+---------
+
+Filter nodes or edges by any statistic:
+
+.. code-block:: python
+
+   H.nodes.filterby('degree', 2)                      # degree == 2
+   H.nodes.filterby('degree', 2, mode='gt')           # degree > 2
+   H.nodes.filterby('degree', (2, 5), mode='between') # 2 <= degree <= 5
+   H.edges.filterby('order', 1, mode='leq')           # order <= 1
+
+Available modes: ``eq``, ``neq``, ``lt``, ``gt``, ``leq``, ``geq``, ``between``.
+
+Filter by attributes:
+
+.. code-block:: python
+
+   H.nodes.filterby_attr('color', 'red')
+   H.nodes.filterby_attr('age', 18, mode='geq')
+
+Multiple statistics
+-------------------
+
+Combine multiple stats into a single DataFrame:
+
+.. code-block:: python
+
+   H.nodes.multi(['degree', 'clustering_coefficient']).aspandas()
+
+Custom statistics
+-----------------
+
+Define your own stats with decorators:
+
+.. code-block:: python
+
+   @xgi.nodestat_func
+   def my_stat(net, bunch):
+       return {n: net.degree(n) ** 2 for n in bunch}
+
+   H.nodes.my_stat.asdict()  # works like any built-in stat
+
+Using stats with visualization
+------------------------------
+
+Pass stat objects directly to drawing functions:
+
+.. code-block:: python
+
+   xgi.draw(H, node_fc=H.nodes.degree, node_size=H.nodes.degree)
+   xgi.draw(H, edge_fc=H.edges.order)

--- a/docs/source/user_guides.rst
+++ b/docs/source/user_guides.rst
@@ -2,6 +2,10 @@
 User Guides
 ***********
 
+.. toctree::
+   :hidden:
+
+   stats_cheatsheet
 
 .. grid::
 	
@@ -92,5 +96,25 @@ User Guides
             :click-parent:
 
             To the cookbook
+
+.. grid::
+
+    .. grid-item-card::
+    	:text-align: center
+
+    	Stats Cheat Sheet
+    	^^^
+
+    	Quick reference for all node and edge statistics,
+    	output formats, filtering, and more.
+
+    	+++
+
+        .. button-ref:: stats_cheatsheet
+            :expand:
+            :color: secondary
+            :click-parent:
+
+            To the stats cheat sheet
 
 For all specifications and options of a particular function, or to explore all existing functions, see the `API Reference <reference.html>`_.

--- a/tutorials/focus/Tutorial 6 - Statistics.ipynb
+++ b/tutorials/focus/Tutorial 6 - Statistics.ipynb
@@ -14,11 +14,7 @@
    "id": "22c91ad1",
    "metadata": {},
    "source": [
-    "You may have noticed that most of the functionality in the `Hypergraph` and `SimplicialComplex` classes takes care of modifying the unerlying structure of the network, and that these classes provide very limited functionality to compute statistics (a.k.a. measures) from the network. This is done via the `stats` package, explored here.\n",
-    "\n",
-    "The stats package is one of the features that sets `xgi` apart from other libraries.  It\n",
-    "provides a common interface to all statistics that can be computed from a network, its\n",
-    "nodes, or edges."
+    "You may have noticed that most of the functionality in the `Hypergraph` and `SimplicialComplex` classes takes care of modifying the unerlying structure of the network, and that these classes provide very limited functionality to compute statistics (a.k.a. measures) from the network. This is done via the `stats` package, explored here.\n\nThe stats package is one of the features that sets `xgi` apart from other libraries.  It\nprovides a common interface to all statistics that can be computed from a network, its\nnodes, or edges.\n\n> **Quick reference:** See the [Stats Cheat Sheet](https://xgi.readthedocs.io/en/stable/stats_cheatsheet.html) for a one-page summary of output formats, filtering, custom stats, and more."
    ]
   },
   {

--- a/tutorials/getting_started/XGI in 5 minutes.ipynb
+++ b/tutorials/getting_started/XGI in 5 minutes.ipynb
@@ -410,36 +410,57 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "dict: {0: 3, 1: 7, 2: 3, 3: 4, 4: 5, 5: 1, 6: 5, 7: 4, 8: 9, 9: 6, 10: 5, 11: 1, 12: 2, 13: 1, 14: 4, 15: 3, 16: 4, 17: 3, 18: 3, 19: 6}\n",
+      "list: [3, 7, 3, 4, 5, 1, 5, 4, 9, 6, 5, 1, 2, 1, 4, 3, 4, 3, 3, 6]\n",
+      "max: 9\n",
+      "mean: 3.95\n"
+     ]
+    }
+   ],
    "source": [
     "# Stat objects support multiple output formats\n",
-    "print(\"dict:\", H_new.nodes.degree.asdict())\n",
-    "print(\"max:\", H_new.nodes.degree.max())\n",
-    "print(\"mean:\", round(H_new.nodes.degree.mean(), 2))"
+    "print(\"dict:\", H.nodes.degree.asdict())\n",
+    "print(\"list:\", H.nodes.degree.aslist())\n",
+    "print(\"max:\", H.nodes.degree.max())\n",
+    "print(\"mean:\", round(H.nodes.degree.mean(), 2))"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "You can also filter nodes or edges by any statistic. For example, to find all nodes with degree greater than 10:"
+    "You can also filter nodes or edges by any statistic. For example, to find all nodes with degree at least 5:"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Nodes with degree >= 5: [1, 4, 6, 8, 9, 10, 19]\n"
+     ]
+    }
+   ],
    "source": [
-    "high_degree_nodes = H_new.nodes.filterby(\"degree\", 10, mode=\"gt\")\n",
-    "print(f\"Nodes with degree > 10: {list(high_degree_nodes)}\")"
+    "high_degree_nodes = H.nodes.filterby(\"degree\", 5, mode=\"geq\")\n",
+    "print(f\"Nodes with degree >= 5: {list(high_degree_nodes)}\")"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Every built-in statistic works the same way. Try `H_new.nodes.clustering_coefficient`, `H_new.edges.size`, or use tab completion to explore what is available. For a deeper dive, check out the [focus tutorial on statistics](https://xgi.readthedocs.io/en/stable/api/tutorials/focus_6.html) or the [stats cheat sheet](https://xgi.readthedocs.io/en/stable/stats_cheatsheet.html)."
+    "Every built-in statistic works the same way. Try `H.nodes.clustering_coefficient`, `H.edges.size`, or use tab completion to explore what is available. ",
+    "For a deeper dive, check out the [focus tutorial on statistics](https://xgi.readthedocs.io/en/stable/api/tutorials/focus_6.html) or the [stats cheat sheet](https://xgi.readthedocs.io/en/stable/stats_cheatsheet.html)."
    ]
   },
   {

--- a/tutorials/getting_started/XGI in 5 minutes.ipynb
+++ b/tutorials/getting_started/XGI in 5 minutes.ipynb
@@ -403,11 +403,52 @@
   },
   {
    "cell_type": "markdown",
+   "source": "## The stats interface\n\nIn the examples above, `H.nodes.degree` and `H.edges.order` are not just methods that return lists. They are **stat objects** that provide a unified interface for any node or edge quantity. You can convert them to different formats, compute summary statistics, and filter your data \u2014 all with the same syntax.",
+   "metadata": {}
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Stat objects support multiple output formats\n",
+    "print(\"dict:\", H_new.nodes.degree.asdict())\n",
+    "print(\"max:\", H_new.nodes.degree.max())\n",
+    "print(\"mean:\", round(H_new.nodes.degree.mean(), 2))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "You can also filter nodes or edges by any statistic. For example, to find all nodes with degree greater than 10:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "high_degree_nodes = H_new.nodes.filterby(\"degree\", 10, mode=\"gt\")\n",
+    "print(f\"Nodes with degree > 10: {list(high_degree_nodes)}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Every built-in statistic works the same way. Try `H_new.nodes.clustering_coefficient`, `H_new.edges.size`, or use tab completion to explore what is available. For a deeper dive, check out the [focus tutorial on statistics](https://xgi.readthedocs.io/en/stable/api/tutorials/focus_6.html) or the [stats cheat sheet](https://xgi.readthedocs.io/en/stable/stats_cheatsheet.html)."
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "metadata": {},
    "source": [
     "## Wrapping Up\n",
     "\n",
-    "Well done! 👏 You've covered a lot in just 5 minutes with XGI. We hope you enjoyed this tutorial, and there's much more to explore! Check out other tutorials [here](https://xgi.readthedocs.io/en/stable/user_guides.html)!"
+    "Well done! \ud83d\udc4f You've covered a lot in just 5 minutes with XGI. We hope you enjoyed this tutorial, and there's much more to explore! Check out other tutorials [here](https://xgi.readthedocs.io/en/stable/user_guides.html)!"
    ]
   }
  ],


### PR DESCRIPTION
## Summary
- **Revise "XGI in 5 minutes"**: Added a new section after the histograms that introduces the stats interface — stat objects, output formats (`asdict`, `mean`, `max`), and `filterby`. Users now encounter the stats system within their first 5 minutes.
- **Add stats cheat sheet**: New one-page reference covering all stats, output formats, summary methods, filter modes, custom stats, multi-stats, and visualization integration.
- **Link quickstart notebook**: The comprehensive `quickstart.ipynb` (81 cells) was orphaned — not linked from the Getting Started index. Now listed as the 4th getting started tutorial.

## Motivation
The stats system is XGI's most powerful feature but users didn't encounter it until Focus Tutorial 6 (the 6th of 7 feature tutorials). These changes ensure users discover it early and have a quick reference to come back to.

Part of a broader docs revamp effort tracked in xgi-igm.

## Test plan
- [x] "XGI in 5 minutes" notebook runs without errors
- [x] Docs build cleanly (no RST warnings)
- [x] Full test suite passes (392 passed, 6 skipped)
- [ ] Review rendered cheat sheet on ReadTheDocs preview

🤖 Generated with [Claude Code](https://claude.com/claude-code)