### PR TITLE
fix: update ReadTheDocs OS to ubuntu-24.04

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -7,7 +7,7 @@ version: 2
 
 # Set the version of Python and other tools you might need
 build:
-  os: ubuntu-20.04
+  os: ubuntu-24.04
   tools:
     python: "3.12"
 


### PR DESCRIPTION
Closes #702

`ubuntu-20.04` has been deprecated by ReadTheDocs, causing build failures. Updates to `ubuntu-24.04`.

cc @nwlandry

🤖 Generated with [Claude Code](https://claude.com/claude-code)