### PR TITLE
feat: forward stat function docstrings to stat objects

### DIFF
--- a/tests/core/test_views.py
+++ b/tests/core/test_views.py
@@ -594,3 +594,26 @@ def test_custom_stat_still_works():
 
     H = xgi.Hypergraph([[1, 2]])
     assert H.nodes.my_custom_stat.asdict() == {1: 42, 2: 42}
+
+
+def test_stat_docstring_forwarding():
+    """Stat objects should expose the underlying function's docstring."""
+    H = xgi.Hypergraph([[1, 2, 3], [3, 4, 5]])
+
+    assert "degree" in H.nodes.degree.__doc__.lower()
+    assert "order" in H.edges.order.__doc__.lower()
+
+    # Calling with args should preserve the docstring
+    assert H.nodes.degree(order=2).__doc__ == H.nodes.degree.__doc__
+
+    # Custom stats should forward their docstring too
+    @xgi.nodestat_func
+    def my_stat(net, bunch):
+        """My custom docstring."""
+        return {n: 1 for n in bunch}
+
+    assert H.nodes.my_stat.__doc__ == "My custom docstring."
+
+    # Directed hypergraph stats
+    DH = xgi.DiHypergraph([([1, 2], [3, 4])])
+    assert "in-degree" in DH.nodes.in_degree.__doc__.lower()

--- a/xgi/stats/__init__.py
+++ b/xgi/stats/__init__.py
@@ -71,6 +71,7 @@ class IDStat:
         self.args = () if args is None else args
         self.kwargs = {} if kwargs is None else kwargs
         self.func = func
+        self.__doc__ = func.__doc__
 
     def __call__(self, *args, **kwargs):
         return self.__class__(self.net, self.view, self.func, args=args, kwargs=kwargs)


### PR DESCRIPTION
## Summary

- `H.nodes.degree?` now shows the actual degree docstring (parameters, description) instead of the generic `NodeStat` class docstring
- One-line change: `self.__doc__ = func.__doc__` in `IDStat.__init__`
- Works for all stat types: node, edge, directed, custom, and with args

Closes #357 (the last remaining point — discoverability was addressed by #699)

## Test plan

- [x] New test `test_stat_docstring_forwarding` covers node stats, edge stats, args preservation, custom stats, and directed hypergraph stats
- [x] Full test suite passes (396 passed)
- [x] Manually verified in IPython