### PR TITLE
fix: issue #718

### DIFF
--- a/tests/convert/test_incidence.py
+++ b/tests/convert/test_incidence.py
@@ -11,3 +11,16 @@ def test_to_incidence_matrix(edgelist5, incidence5):
 def test_from_incidence_matrix(edgelist5, incidence5):
     H = xgi.from_incidence_matrix(incidence5)
     assert H.edges.members() == edgelist5
+
+
+def test_fix_718():
+    # Adding an edge after from_incidence_matrix must not collide with existing edge IDs
+    B = np.array([[1, 1, 0], [1, 0, 1], [0, 1, 1]])
+    H = xgi.from_incidence_matrix(B)
+    H.add_edge([0, 3])
+    assert H.edges.members(dtype=dict) == {
+        0: {0, 1},
+        1: {0, 2},
+        2: {1, 2},
+        3: {0, 3},
+    }

--- a/xgi/core/dihypergraph.py
+++ b/xgi/core/dihypergraph.py
@@ -824,6 +824,7 @@ class DiHypergraph:
         if edge not in self._edge:
             self._edge[edge] = {"in": set(), "out": set()}
             self._edge_attr[edge] = {}
+            update_uid_counter(self, edge)
         if node not in self._node:
             self._node[node] = {"in": set(), "out": set()}
             self._node_attr[node] = {}

--- a/xgi/core/hypergraph.py
+++ b/xgi/core/hypergraph.py
@@ -1110,6 +1110,7 @@ class Hypergraph:
         if edge not in self._edge:
             self._edge[edge] = set()
             self._edge_attr[edge] = {}
+            update_uid_counter(self, edge)
         if node not in self._node:
             self._node[node] = set()
             self._node_attr[node] = {}


### PR DESCRIPTION
`add_node_to_edge()` now correctly updates the edge uid count. 

In addition to `from_incidence_matrix()`, the function `add_node_to_edge()`  is also called by `from_bipartite_graph()`, `from_hif_dict()`, `from_bipartite_pandas_dataframe`, and `from_bipartite_edgelist`. 

The fix was a single line, and I added a test to check that it works.
This solves #718.