### PR TITLE
fix: account for idx=0 when adding edges

### DIFF
--- a/tests/core/test_hypergraph.py
+++ b/tests/core/test_hypergraph.py
@@ -1000,3 +1000,27 @@ def test_cleanup():
     assert cleanH["name"] == "test"
 
     assert cleanH._edge == xgi.dual_dict(cleanH._node)
+
+
+def test_fix_720():
+    # idx=0 must be treated as a valid user-provided ID, not as "no ID given"
+
+    # Hypergraph.add_edge: counter must advance past 0 so the next auto-ID doesn't collide
+    H = xgi.Hypergraph()
+    H.add_edge([1, 2], idx=0)
+    H.add_edge([2, 3])
+    assert H.edges.members(dtype=dict) == {0: {1, 2}, 1: {2, 3}}
+
+    # DiHypergraph.add_edge: same check for directed hypergraphs
+    D = xgi.DiHypergraph()
+    D.add_edge(([1], [2]), idx=0)
+    D.add_edge(([2], [3]))
+    assert D.edges.members(dtype=dict) == {0: {1, 2}, 1: {2, 3}}
+
+    # SimplicialComplex.add_simplex: idx=0 must not be replaced by an auto-generated ID.
+    # Use idx=3 first to advance the counter past 0; without the fix, the subsequent
+    # add_simplex with idx=0 would silently use the counter value instead.
+    S = xgi.SimplicialComplex()
+    S.add_simplex([1, 2], idx=3)
+    S.add_simplex([3, 4], idx=0)
+    assert S.edges.members(dtype=dict)[0] == {3, 4}

--- a/xgi/core/dihypergraph.py
+++ b/xgi/core/dihypergraph.py
@@ -581,7 +581,7 @@ class DiHypergraph:
         self._edge_attr[uid] = self._edge_attr_dict_factory()
         self._edge_attr[uid].update(attr)
 
-        if idx:  # set self._edge_uid correctly
+        if idx is not None:  # set self._edge_uid correctly
             update_uid_counter(self, idx)
 
     def add_edges_from(self, ebunch_to_add, **attr):

--- a/xgi/core/hypergraph.py
+++ b/xgi/core/hypergraph.py
@@ -627,7 +627,7 @@ class Hypergraph:
         self._edge_attr[uid] = self._edge_attr_dict_factory()
         self._edge_attr[uid].update(attr)
 
-        if idx:  # set self._edge_uid correctly
+        if idx is not None:  # set self._edge_uid correctly
             update_uid_counter(self, idx)
 
     def add_edges_from(self, ebunch_to_add, **attr):

--- a/xgi/core/simplicialcomplex.py
+++ b/xgi/core/simplicialcomplex.py
@@ -314,7 +314,7 @@ class SimplicialComplex(Hypergraph):
             warn(f"uid {idx} already exists, cannot add simplex {members}")
             return
 
-        idx = next(self._edge_uid) if not idx else idx
+        idx = next(self._edge_uid) if idx is None else idx
 
         self._add_simplex(members, idx, **attr)
 


### PR DESCRIPTION
Fixes #720 . `if idx:` / `if not idx:` evaluates incorrectly when `idx=0`. Replaced with explicit `None` checks in `Hypergraph.add_edge`, `DiHypergraph.add_edge`,  and `SimplicialComplex.add_simplex`.
