### PR TITLE
fix: accept np.random.Generator as seed in spring layouts (#712)

### DIFF
--- a/tests/drawing/test_layout.py
+++ b/tests/drawing/test_layout.py
@@ -270,3 +270,41 @@ def test_spring_layouts_accept_rng(edgelist1):
     xgi.barycenter_spring_layout(H, seed=42)
     # None still works
     xgi.barycenter_spring_layout(H, seed=None)
+
+
+def test_spring_layouts_rng_semantics(edgelist1):
+    """Document expected reproducibility semantics for the seed argument.
+
+    The conventions mirror sklearn / scipy:
+
+    * Reusing the same `Generator` instance advances its state, so two
+      consecutive calls produce different layouts.
+    * Two fresh `Generator`s constructed from the same seed produce identical
+      layouts.
+    * Passing an int seed reproduces itself, but is not equivalent to passing a
+      `Generator` constructed from that same int (the conversion path differs).
+    """
+    H = xgi.Hypergraph(edgelist1)
+
+    # Reusing one rng across calls: state advances → different outputs
+    rng = np.random.default_rng(42)
+    pos_a = xgi.barycenter_spring_layout(H, seed=rng)
+    pos_b = xgi.barycenter_spring_layout(H, seed=rng)
+    assert any(not np.allclose(pos_a[n], pos_b[n]) for n in pos_a)
+
+    # Two fresh rngs from the same seed → identical outputs
+    pos_c = xgi.barycenter_spring_layout(H, seed=np.random.default_rng(42))
+    pos_d = xgi.barycenter_spring_layout(H, seed=np.random.default_rng(42))
+    for n in pos_c:
+        assert np.allclose(pos_c[n], pos_d[n])
+
+    # Same int seed reused → identical outputs
+    pos_e = xgi.barycenter_spring_layout(H, seed=42)
+    pos_f = xgi.barycenter_spring_layout(H, seed=42)
+    for n in pos_e:
+        assert np.allclose(pos_e[n], pos_f[n])
+
+    # int seed vs rng built from same seed → NOT equivalent (different paths)
+    pos_g = xgi.barycenter_spring_layout(H, seed=42)
+    pos_h = xgi.barycenter_spring_layout(H, seed=np.random.default_rng(42))
+    assert any(not np.allclose(pos_g[n], pos_h[n]) for n in pos_g)

--- a/tests/drawing/test_layout.py
+++ b/tests/drawing/test_layout.py
@@ -253,3 +253,20 @@ def test_edge_positions_from_barycenters(edgelist1):
     for idx, e in H.edges.members(dtype=dict).items():
         mean_pos = np.mean([node_pos[n] for n in e], axis=0)
         assert np.allclose(edge_pos[idx], mean_pos)
+
+
+def test_spring_layouts_accept_rng(edgelist1):
+    """Spring layouts should accept np.random.Generator as seed (issue #712)."""
+    H = xgi.Hypergraph(edgelist1)
+    rng = np.random.default_rng(42)
+
+    # All four spring layouts should accept a Generator without erroring
+    xgi.pairwise_spring_layout(H, seed=rng)
+    xgi.barycenter_spring_layout(H, seed=rng)
+    xgi.weighted_barycenter_spring_layout(H, seed=rng)
+    xgi.bipartite_spring_layout(H, seed=rng)
+
+    # int seed still works
+    xgi.barycenter_spring_layout(H, seed=42)
+    # None still works
+    xgi.barycenter_spring_layout(H, seed=None)

--- a/xgi/drawing/layout.py
+++ b/xgi/drawing/layout.py
@@ -22,6 +22,15 @@ __all__ = [
 ]
 
 
+def _to_nx_seed(seed):
+    # NetworkX's spring_layout doesn't accept np.random.Generator yet
+    # (it calls seed.rand(...), which only exists on legacy RandomState).
+    # Draw a fresh int from the rng so the user's Generator still advances.
+    if isinstance(seed, np.random.Generator):
+        return int(seed.integers(0, 2**32 - 1))
+    return seed
+
+
 def random_layout(H, center=None, seed=None):
     """Position nodes uniformly at random in the unit square.
 
@@ -130,7 +139,7 @@ def pairwise_spring_layout(H, seed=None, k=None, **kwargs):
     if isinstance(H, SimplicialComplex):
         H = convert.from_max_simplices(H)
     G = convert.to_graph(H)
-    pos = nx.spring_layout(G, seed=seed, k=k, **kwargs)
+    pos = nx.spring_layout(G, seed=_to_nx_seed(seed), k=k, **kwargs)
     return pos
 
 
@@ -231,7 +240,7 @@ def bipartite_spring_layout(H, seed=None, k=None, **kwargs):
 
     # Creating a dictionary for the position of the nodes with the standard spring
     # layout
-    pos = nx.spring_layout(G, seed=seed, k=k, **kwargs)
+    pos = nx.spring_layout(G, seed=_to_nx_seed(seed), k=k, **kwargs)
 
     node_pos = {nodedict[i]: pos[i] for i in nodedict}
     edge_pos = {edgedict[i]: pos[i] for i in edgedict}
@@ -340,7 +349,7 @@ def barycenter_spring_layout(
 
     # Creating a dictionary for the position of the nodes with the standard spring
     # layout
-    pos_with_phantom_nodes = nx.spring_layout(G, seed=seed, k=k, **kwargs)
+    pos_with_phantom_nodes = nx.spring_layout(G, seed=_to_nx_seed(seed), k=k, **kwargs)
 
     # Retaining only the positions of the real nodes
     pos = {k: pos_with_phantom_nodes[k] for k in list(H.nodes)}
@@ -412,7 +421,7 @@ def weighted_barycenter_spring_layout(
 
     # Creating a dictionary for node position with the standard spring layout
     pos_with_phantom_nodes = nx.spring_layout(
-        G, weight="weight", seed=seed, k=k, **kwargs
+        G, weight="weight", seed=_to_nx_seed(seed), k=k, **kwargs
     )
 
     # Retaining only the positions of the real nodes


### PR DESCRIPTION
## Summary

Fixes #712. NetworkX's `spring_layout` calls `seed.rand(...)`, which only exists on the legacy `RandomState`. After #689 made our APIs accept `np.random.Generator` for `seed`, the four xgi layout functions that wrap `nx.spring_layout` started erroring when a `Generator` was passed.

The fix is a 5-line helper that draws a fresh integer from the rng (so the user's `Generator` still advances) and passes that to NetworkX. When NetworkX eventually accepts `Generator` natively, the helper can be deleted.

Applied at all four call sites:
- `pairwise_spring_layout`
- `barycenter_spring_layout`
- `weighted_barycenter_spring_layout`
- `bipartite_spring_layout`

## Test plan

- [x] New regression test `test_spring_layouts_accept_rng` covers all four functions with a `Generator`, an `int`, and `None`
- [x] Full test suite passes (410 passed, 6 skipped)
- [x] Manually verified the original repro from #712 now works