### PR TITLE
feat: add empties option to cleanup methods (#570)

### DIFF
--- a/tests/core/test_hypergraph.py
+++ b/tests/core/test_hypergraph.py
@@ -1000,3 +1000,22 @@ def test_cleanup():
     assert cleanH["name"] == "test"
 
     assert cleanH._edge == xgi.dual_dict(cleanH._node)
+
+
+def test_cleanup_empties():
+    """cleanup should remove empty edges by default and keep them with empties=True."""
+    H = xgi.Hypergraph([[1, 2, 3], [3, 4]])
+    H._edge[2] = set()
+    H._edge_attr[2] = {}
+    assert H.num_edges == 3
+    assert set(H.edges.empty()) == {2}
+
+    # default: remove empties
+    cleanH = H.cleanup(connected=False, relabel=False, in_place=False)
+    assert cleanH.num_edges == 2
+    assert set(cleanH.edges.empty()) == set()
+
+    # empties=True: keep them
+    cleanH = H.cleanup(connected=False, empties=True, relabel=False, in_place=False)
+    assert cleanH.num_edges == 3
+    assert set(cleanH.edges.empty()) == {2}

--- a/xgi/core/dihypergraph.py
+++ b/xgi/core/dihypergraph.py
@@ -1041,12 +1041,14 @@ class DiHypergraph:
 
         return cp
 
-    def cleanup(self, isolates=False, relabel=True, in_place=True):
+    def cleanup(self, isolates=False, empties=False, relabel=True, in_place=True):
         if in_place:
             _DH = self
         else:
             _DH = self.copy()
 
+        if not empties:
+            _DH.remove_edges_from(_DH.edges.empty())
         if not isolates:
             _DH.remove_nodes_from(_DH.nodes.isolates())
         if relabel:

--- a/xgi/core/hypergraph.py
+++ b/xgi/core/hypergraph.py
@@ -1469,6 +1469,7 @@ class Hypergraph:
         self,
         isolates=False,
         singletons=False,
+        empties=False,
         multiedges=False,
         connected=True,
         relabel=True,
@@ -1482,6 +1483,8 @@ class Hypergraph:
             Whether isolated nodes are allowed, by default False.
         singletons : bool, optional
             Whether singleton edges are allowed, by default False.
+        empties : bool, optional
+            Whether empty edges (edges with no nodes) are allowed, by default False.
         multiedges : bool, optional
             Whether multiedges are allowed, by default False.
         connected : bool, optional
@@ -1504,6 +1507,8 @@ class Hypergraph:
             _H.merge_duplicate_edges()
         if not singletons:
             _H.remove_edges_from(_H.edges.singletons())
+        if not empties:
+            _H.remove_edges_from(_H.edges.empty())
         if not isolates:
             _H.remove_nodes_from(_H.nodes.isolates())
         if connected:

--- a/xgi/core/simplicialcomplex.py
+++ b/xgi/core/simplicialcomplex.py
@@ -831,11 +831,15 @@ class SimplicialComplex(Hypergraph):
 
         return cp
 
-    def cleanup(self, isolates=False, connected=True, relabel=True, in_place=True):
+    def cleanup(
+        self, isolates=False, empties=False, connected=True, relabel=True, in_place=True
+    ):
         if in_place:
             _S = self
         else:
             _S = self.copy()
+        if not empties:
+            _S.remove_simplex_ids_from(_S.edges.empty())
         if not isolates:
             _S.remove_nodes_from(_S.nodes.isolates())
         if connected:


### PR DESCRIPTION
## Summary

Closes #570. Adds an `empties` parameter to `cleanup()` on `Hypergraph`, `DiHypergraph`, and `SimplicialComplex`. Defaults to `False` (matching the convention of the other cleanup flags like `singletons` and `multiedges`), so empty edges are removed by default.

Empty edges aren't trivial to create through normal use, but they can arise from manual data manipulation or from external data sources, and there was no clean way to strip them out.

`H.edges.empty()` already existed as a view filter, so removing them outside `cleanup` is also straightforward:

```python
H.remove_edges_from(H.edges.empty())
```

## Test plan

- [x] Added `test_cleanup_empties` regression test
- [x] Full test suite passes (410 passed, 6 skipped)