### PR TITLE
feat: add H.nodes.pos stat accessor for node positions (#624)

### DIFF
--- a/docs/source/api/stats.rst
+++ b/docs/source/api/stats.rst
@@ -28,6 +28,7 @@ stats package
       ~xgi.stats.nodestats.h_eigenvector_centrality
       ~xgi.stats.nodestats.local_clustering_coefficient
       ~xgi.stats.nodestats.node_edge_centrality
+      ~xgi.stats.nodestats.pos
       ~xgi.stats.nodestats.two_node_clustering_coefficient
 
    *Statistics of edges*
@@ -78,6 +79,7 @@ stats package
       ~xgi.stats.dinodestats.degree
       ~xgi.stats.dinodestats.in_degree
       ~xgi.stats.dinodestats.out_degree
+      ~xgi.stats.dinodestats.pos
 
    *Statistics of edges*
 

--- a/docs/source/stats_cheatsheet.rst
+++ b/docs/source/stats_cheatsheet.rst
@@ -96,6 +96,8 @@ Available node statistics
      - ``H.nodes.katz_centrality``
    * - ``attrs``
      - ``H.nodes.attrs('color')``
+   * - ``pos``
+     - ``H.nodes.pos`` (shortcut for ``H.nodes.attrs('pos')``)
 
 Available edge statistics
 -------------------------

--- a/tests/core/test_views.py
+++ b/tests/core/test_views.py
@@ -618,3 +618,29 @@ def test_stat_docstring_forwarding():
     # Directed hypergraph stats
     DH = xgi.DiHypergraph([([1, 2], [3, 4])])
     assert "in-degree" in DH.nodes.in_degree.__doc__.lower()
+
+
+def test_pos_stat():
+    """H.nodes.pos accesses the 'pos' node attribute."""
+    H = xgi.Hypergraph([[1, 2, 3]])
+    positions = {1: (0.0, 0.0), 2: (1.0, 0.5), 3: (0.5, 1.0)}
+    H.set_node_attributes(positions, name="pos")
+
+    assert H.nodes.pos.asdict() == positions
+
+    # Nodes without 'pos' attribute return None
+    H2 = xgi.Hypergraph([[1, 2]])
+    assert H2.nodes.pos.asdict() == {1: None, 2: None}
+
+    # Discoverable via dir() and accessible as descriptor
+    assert "pos" in dir(H.nodes)
+
+    # Equivalent to attrs("pos")
+    H.set_node_attributes(positions, name="pos")
+    assert H.nodes.pos.asdict() == H.nodes.attrs("pos").asdict()
+
+    # DiHypergraph too
+    DH = xgi.DiHypergraph([([1, 2], [3, 4])])
+    DH.set_node_attributes({1: (0, 0), 2: (1, 0), 3: (0, 1), 4: (1, 1)}, name="pos")
+    assert DH.nodes.pos.asdict() == {1: (0, 0), 2: (1, 0), 3: (0, 1), 4: (1, 1)}
+    assert "pos" in dir(DH.nodes)

--- a/tutorials/recipes/recipes.ipynb
+++ b/tutorials/recipes/recipes.ipynb
@@ -1165,6 +1165,34 @@
     "pos = xgi.pca_transform(xgi.pairwise_spring_layout(H, seed=0))\n",
     "xgi.draw(H, pos=pos, node_fc=H.nodes.attrs(\"group\"))"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 21. Draw a hypergraph using node positions stored as attributes\n",
+    "\n",
+    "When node positions are stored as the `\"pos\"` node attribute (e.g., produced by a custom layout or saved from a previous run), the `H.nodes.pos` stat provides a one-step accessor that returns the position dict in the form expected by `xgi.draw`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import xgi\n",
+    "import numpy as np\n",
+    "\n",
+    "H = xgi.random_hypergraph(20, [0.1, 0.01], seed=1)\n",
+    "\n",
+    "# Compute and store a layout once, then re-use it as a node attribute\n",
+    "pos = xgi.barycenter_spring_layout(H, seed=1)\n",
+    "H.set_node_attributes(pos, name=\"pos\")\n",
+    "\n",
+    "# Later, retrieve and draw using the stored positions\n",
+    "xgi.draw(H, pos=H.nodes.pos.asdict());"
+   ]
   }
  ],
  "metadata": {

--- a/xgi/core/views.py
+++ b/xgi/core/views.py
@@ -617,6 +617,7 @@ class NodeView(IDView):
     local_simplicial_fraction = _stat_property("local_simplicial_fraction")
     local_edit_simpliciality = _stat_property("local_edit_simpliciality")
     local_face_edit_simpliciality = _stat_property("local_face_edit_simpliciality")
+    pos = _stat_property("pos")
 
     def __init__(self, H, bunch=None):
         if H is None:
@@ -905,6 +906,7 @@ class DiNodeView(IDView):
     degree = _stat_property("degree")
     in_degree = _stat_property("in_degree")
     out_degree = _stat_property("out_degree")
+    pos = _stat_property("pos")
 
     def __init__(self, H, bunch=None):
         if H is None:

--- a/xgi/core/views.pyi
+++ b/xgi/core/views.pyi
@@ -45,6 +45,7 @@ class NodeView(IDView):
     local_simplicial_fraction: NodeStat
     local_edit_simpliciality: NodeStat
     local_face_edit_simpliciality: NodeStat
+    pos: NodeStat
 
     def memberships(self, n: Hashable | None = None) -> dict | set: ...
     def isolates(self, ignore_singletons: bool = False) -> NodeView: ...
@@ -69,6 +70,7 @@ class DiNodeView(IDView):
     degree: DiNodeStat
     in_degree: DiNodeStat
     out_degree: DiNodeStat
+    pos: DiNodeStat
 
     def dimemberships(self, n: Hashable | None = None) -> dict | tuple[set, set]: ...
     def memberships(self, n: Hashable | None = None) -> dict | set: ...

--- a/xgi/drawing/draw.py
+++ b/xgi/drawing/draw.py
@@ -92,7 +92,8 @@ def draw(
     pos : dict, optional
         If passed, this dictionary of positions node_id:(x,y) is used for placing the
         0-simplices.  If None (default), use the `barycenter_spring_layout` to compute
-        the positions.
+        the positions. If positions are stored as the ``"pos"`` node attribute, you
+        can pass ``H.nodes.pos.asdict()`` directly.
     ax : matplotlib.pyplot.axes, optional
         Axis to draw on. If None (default), get the current axes.
     node_fc : str, dict, iterable, or NodeStat, optional

--- a/xgi/stats/dinodestats.py
+++ b/xgi/stats/dinodestats.py
@@ -23,6 +23,7 @@ __all__ = [
     "degree",
     "in_degree",
     "out_degree",
+    "pos",
 ]
 
 
@@ -275,3 +276,30 @@ def out_degree(net, bunch, order=None, weight=None):
             )
             for n in bunch
         }
+
+
+def pos(net, bunch):
+    """Node positions.
+
+    Convenience accessor for the ``"pos"`` node attribute, which xgi's drawing
+    functions use as node coordinates. Equivalent to ``attrs(net, bunch, "pos")``.
+
+    Parameters
+    ----------
+    net : xgi.DiHypergraph
+        The network.
+    bunch : Iterable
+        Nodes in `net`.
+
+    Returns
+    -------
+    dict
+        Maps node id to its ``"pos"`` attribute. Nodes without a ``"pos"``
+        attribute map to ``None``.
+
+    See Also
+    --------
+    attrs
+
+    """
+    return attrs(net, bunch, attr="pos")

--- a/xgi/stats/nodestats.py
+++ b/xgi/stats/nodestats.py
@@ -34,6 +34,7 @@ __all__ = [
     "z_eigenvector_centrality",
     "node_edge_centrality",
     "katz_centrality",
+    "pos",
 ]
 
 
@@ -115,6 +116,46 @@ def attrs(net, bunch, attr=None, missing=None):
         return {n: net._node_attr[n] for n in bunch}
     else:
         raise ValueError('"attr" must be str or None')
+
+
+def pos(net, bunch):
+    """Node positions.
+
+    Convenience accessor for the ``"pos"`` node attribute, which xgi's drawing
+    functions use as node coordinates. Equivalent to ``attrs(net, bunch, "pos")``.
+
+    Parameters
+    ----------
+    net : xgi.Hypergraph
+        The network.
+    bunch : Iterable
+        Nodes in `net`.
+
+    Returns
+    -------
+    dict
+        Maps node id to its ``"pos"`` attribute. Nodes without a ``"pos"``
+        attribute map to ``None``.
+
+    See Also
+    --------
+    attrs
+    ~xgi.drawing.draw : Accepts the result of this stat as the ``pos`` argument.
+
+    Examples
+    --------
+    >>> import xgi
+    >>> H = xgi.Hypergraph([[1, 2, 3]])
+    >>> H.set_node_attributes({1: (0, 0), 2: (1, 0), 3: (0.5, 1)}, name="pos")
+    >>> H.nodes.pos.asdict()
+    {1: (0, 0), 2: (1, 0), 3: (0.5, 1)}
+
+    Pass directly to ``xgi.draw``:
+
+    >>> xgi.draw(H, pos=H.nodes.pos.asdict())  # doctest: +SKIP
+
+    """
+    return attrs(net, bunch, attr="pos")
 
 
 def degree(net, bunch, order=None, weight=None):


### PR DESCRIPTION
## Summary

Closes #624. Adds `pos` as a first-class stat on `NodeView` and `DiNodeView` — a discoverable shortcut for the conventional `\"pos\"` node attribute that xgi's drawing functions use.

Why promote `pos` to a stat? It's already a privileged attribute name in the library (the whole reason the issue exists), and the descriptor pattern from #699 means it now appears in `dir()`, tab completion, and IDE autocomplete. So the natural call site becomes:

```python
xgi.draw(H, pos=H.nodes.pos.asdict())
```

This is what the original issue asked for, achieved without adding a new top-level helper. Nodes without a `\"pos\"` attribute map to `None` (same as `attrs(\"pos\")` does today).

## Changes

- `xgi/stats/nodestats.py`: new `pos` function (3-line body, full docstring)
- `xgi/stats/dinodestats.py`: same, for `DiHypergraph`
- `xgi/core/views.py`: register on `NodeView` and `DiNodeView`
- `xgi/core/views.pyi`: type stubs
- `xgi/drawing/draw.py`: point the `pos` parameter docstring at `H.nodes.pos.asdict()`
- `docs/source/api/stats.rst`: list it under both node-stats sections
- `docs/source/stats_cheatsheet.rst`: add a row
- `tutorials/recipes/recipes.ipynb`: new recipe showing the layout-store-redraw pattern

## Test plan

- [x] New `test_pos_stat` covers `Hypergraph` + `DiHypergraph`, with and without the attribute set, and equivalence to `attrs(\"pos\")`
- [x] Full test suite passes (411 passed, 6 skipped)
- [x] Doctest on the new `pos` function passes