### PR TITLE
feat: add with_positions option to ring_lattice (#623)

### DIFF
--- a/tests/generators/test_lattice.py
+++ b/tests/generators/test_lattice.py
@@ -28,3 +28,19 @@ def test_ring_lattice():
     # k < 0 test
     with pytest.raises(ValueError):
         xgi.ring_lattice(5, 2, -1, 0)
+
+
+def test_ring_lattice_with_positions():
+    from math import cos, pi, sin
+
+    # default: no pos stored
+    H = xgi.ring_lattice(5, 2, 2, 0)
+    assert H.nodes.attrs("pos").asdict() == {i: None for i in range(5)}
+
+    # with_positions=True: each node has a unit-circle coordinate
+    H = xgi.ring_lattice(8, 3, 2, 0, with_positions=True)
+    pos = H.nodes.attrs("pos").asdict()
+    assert set(pos.keys()) == set(range(8))
+    for i, p in pos.items():
+        expected = (cos(2 * pi * i / 8), sin(2 * pi * i / 8))
+        assert p == pytest.approx(expected)

--- a/xgi/generators/lattice.py
+++ b/xgi/generators/lattice.py
@@ -5,6 +5,7 @@ hypergraph).
 
 """
 
+from math import cos, pi, sin
 from warnings import warn
 
 __all__ = [
@@ -12,7 +13,7 @@ __all__ = [
 ]
 
 
-def ring_lattice(n, d, k, l):
+def ring_lattice(n, d, k, l, with_positions=False):
     """A ring lattice hypergraph.
 
     A d-uniform hypergraph on n nodes where each node is part of k edges and the
@@ -28,6 +29,10 @@ def ring_lattice(n, d, k, l):
         Number of edges of which a node is a part. Should be a multiple of 2.
     l : int
         Overlap between edges
+    with_positions : bool, optional
+        If True, store each node's coordinates on a unit circle as the ``"pos"`` node
+        attribute. By default, False. Useful for plotting:
+        ``xgi.draw(H, pos=H.nodes.pos.asdict())``.
 
     Returns
     -------
@@ -63,4 +68,7 @@ def ring_lattice(n, d, k, l):
     ]
     H = Hypergraph(edges)
     H.add_nodes_from(range(n))
+    if with_positions:
+        pos = {i: (cos(2 * pi * i / n), sin(2 * pi * i / n)) for i in range(n)}
+        H.set_node_attributes(pos, name="pos")
     return H


### PR DESCRIPTION
## Summary

Closes #623. Adds a `with_positions=False` keyword argument to `ring_lattice`. When True, stores each node's coordinate on a unit circle as the `\"pos\"` node attribute. Naming follows the NetworkX convention (e.g., `triangular_lattice_graph(with_positions=True)`) as Max suggested in the issue.

Combined with #728 (`H.nodes.pos` accessor), the natural workflow becomes:

```python
H = xgi.ring_lattice(8, 3, 2, 0, with_positions=True)
xgi.draw(H, pos=H.nodes.pos.asdict())
```

`ring_lattice` is currently the only lattice generator in xgi, so this is a one-function change. Future lattice generators (e.g., triangular) should follow the same convention.

## Test plan

- [x] `test_ring_lattice_with_positions` covers both default (no pos) and `with_positions=True` (verifies unit-circle coordinates)
- [x] Full test suite passes (411 passed, 6 skipped)