### PR TITLE
Docs: fix match between accepted formats and docs

### DIFF
--- a/xgi/convert/higher_order_network.py
+++ b/xgi/convert/higher_order_network.py
@@ -30,6 +30,8 @@ def to_hypergraph(data, create_using=None):
         Current known types are:
          * a Hypergraph object
          * a SimplicialComplex object
+         * a DiHypergraph object: each directed edge (tail, head) is converted
+           to an undirected edge containing the union of its tail and head members
          * list-of-iterables
          * dict-of-iterables
          * Pandas DataFrame (bipartite edgelist)
@@ -104,13 +106,12 @@ def to_dihypergraph(data, create_using=None):
     data : object to be converted
         Current known types are:
          * a DiHypergraph object
-         * a SimplicialComplex object
          * list-of-iterables
          * dict-of-iterables
-         * Pandas DataFrame (bipartite edgelist)
-         * numpy matrix
-         * numpy ndarray
-         * scipy sparse matrix
+
+        .. note::
+            Pandas DataFrame, numpy, and scipy sparse inputs are not yet
+            implemented and will raise an error.
     create_using : Hypergraph constructor, optional (default=Hypergraph)
         Hypergraph type to create. If hypergraph instance, then cleared before populated.
 
@@ -165,9 +166,10 @@ def to_simplicial_complex(data, create_using=None):
          * list-of-iterables
          * dict-of-iterables
          * Pandas DataFrame (bipartite edgelist)
-         * numpy matrix
-         * numpy ndarray
-         * scipy sparse matrix
+
+        .. note::
+            Construction from an incidence matrix (numpy ndarray or scipy.sparse
+            array) is not yet implemented and will raise an error.
     create_using : Hypergraph graph constructor, optional (default=Hypergraph)
         Hypergraph type to create. If hypergraph instance, then cleared before
         populated.

--- a/xgi/core/hypergraph.py
+++ b/xgi/core/hypergraph.py
@@ -40,6 +40,8 @@ class Hypergraph:
         * Incidence matrix: numpy ndarray or scipy.sparse array
         * Hypergraph object
         * SimplicialComplex object
+        * DiHypergraph object: each directed edge (tail, head) is converted to
+          an undirected edge containing the union of its tail and head members.
 
     **attr : dict, optional
         Attributes to add to the hypergraph as key, value pairs.

--- a/xgi/core/simplicialcomplex.py
+++ b/xgi/core/simplicialcomplex.py
@@ -45,9 +45,12 @@ class SimplicialComplex(Hypergraph):
         * simplex list
         * simplex dictionary
         * 2-column Pandas dataframe (bipartite edges)
-        * Incidence matrix: numpy ndarray or scipy.sparse array
         * SimplicialComplex object
         * Hypergraph object
+
+        .. note::
+            Construction from an incidence matrix (numpy ndarray or scipy.sparse
+            array) is not yet implemented and will raise an error.
 
     **attr : dict, optional
         Attributes to add to the simplicial complex as key, value pairs.


### PR DESCRIPTION
This fixes #643 and related issues by:
- ensuring docs and accepted formats match
- adding a note where certain formats are not yet implemented

This affects `SimplicialComplex.__init__`, `to_dihypergraph()`, and `to_simplicial_complex()`, `Hypergraph.__init__ ` and `to_hypergraph()`.