### PR TITLE
Optimize `node_swap`

### DIFF
--- a/tests/generators/test_randomizing.py
+++ b/tests/generators/test_randomizing.py
@@ -79,6 +79,7 @@ def test_shuffle_hyperedges():
 def test_node_swap(edgelist8):
 
     H0 = xgi.Hypergraph(edgelist8)
+    edges_orig = dict(H0._edge)
 
     H = xgi.node_swap(H0, 2, 5)  # all orders
     edges_new = {
@@ -92,23 +93,18 @@ def test_node_swap(edgelist8):
         7: {1, 6},
         8: {0, 6},
     }
-
     assert H._edge == edges_new
 
-    # id temp already exists
-    H = xgi.node_swap(H0, 2, 5, id_temp=1)
-    edges_new = {
-        0: {0, 1},
-        1: {0, 1, 5},
-        2: {0, 5, 3},
-        3: {0, 1, 5, 3, 4},
-        4: {5, 4, 2},
-        5: {1, 3, 2},
-        6: {0, 3, 4},
-        7: {1, 6},
-        8: {0, 6},
-    }
-    assert H._edge == edges_new
+    # original is not modified
+    assert H0._edge == edges_orig
+
+    # edges containing neither swapped node are unchanged
+    assert H._edge[0] == H0._edge[0]  # {0, 1}
+    assert H._edge[6] == H0._edge[6]  # {0, 3, 4}
+    assert H._edge[7] == H0._edge[7]  # {1, 6}
+
+    # edge containing both swapped nodes is unchanged (swap is self-inverse on that edge)
+    assert H._edge[4] == H0._edge[4]  # {2, 4, 5}: 2<->5 leaves the set identical
 
     # selected order
     H = xgi.node_swap(H0, 2, 5, order=2)
@@ -124,6 +120,18 @@ def test_node_swap(edgelist8):
         8: {0, 6},
     }
     assert H._edge == edges_new
+
+    # node attributes are preserved after swap
+    H0_attrs = xgi.Hypergraph(edgelist8)
+    H0_attrs.nodes[2]["color"] = "red"
+    H0_attrs.nodes[5]["color"] = "blue"
+    H_attrs = xgi.node_swap(H0_attrs, 2, 5)
+    assert H_attrs.nodes[2]["color"] == "red"
+    assert H_attrs.nodes[5]["color"] == "blue"
+
+    # symmetry: swapping A,B then B,A returns the original edges
+    H_twice = xgi.node_swap(xgi.node_swap(H0, 2, 5), 2, 5)
+    assert H_twice._edge == edges_orig
 
     # errors raised
     with pytest.raises(ValueError):

--- a/xgi/generators/randomizing.py
+++ b/xgi/generators/randomizing.py
@@ -4,8 +4,6 @@ All the functions in this module return a Hypergraph class (i.e. a simple, undir
 hypergraph).
 """
 
-from copy import deepcopy
-
 import numpy as np
 
 import xgi
@@ -84,7 +82,7 @@ def shuffle_hyperedges(S, order, p, seed=None):
     return H
 
 
-def node_swap(H, nid1, nid2, id_temp=-1, order=None):
+def node_swap(H, nid1, nid2, order=None):
     """Swap nodes `nid1` and node `nid2` in all edges of order `order`.
 
     Parameters
@@ -95,8 +93,6 @@ def node_swap(H, nid1, nid2, id_temp=-1, order=None):
         ID of first node to swap
     nid2: node ID
         ID of second node to swap
-    id_temp: node ID
-        Temporary ID given to nodes when swapping
     order: {int, None}, default: None
         If None, consider all orders. If an integer,
         consider edges of that order.
@@ -127,10 +123,6 @@ def node_swap(H, nid1, nid2, id_temp=-1, order=None):
                 f"There is no hyperedge of order {order} is this hypergraph."
             )
 
-    # make sure id_temps does not exist yet
-    while id_temp in H.edges:
-        id_temp -= 1
-
     # get edges of given order
     if order:
         edge_dict = H.edges.filterby("order", order).members(dtype=dict).copy()
@@ -147,29 +139,14 @@ def node_swap(H, nid1, nid2, id_temp=-1, order=None):
             f"Node {nid2} is not part of any hyperedge of the specified order"
         )
 
-    new_edge_dict = deepcopy(edge_dict)
     HH = H.copy()
 
-    # replace nid1 by temporary id in edges
-    for key, members in edge_dict.items():
-        if nid1 in members:
-            members.remove(nid1)
-            members.add(id_temp)
-        new_edge_dict[key] = members
-
-    # replace nid2 by nid1 in edges
-    for key, members in new_edge_dict.items():
-        if nid2 in members:
-            members.remove(nid2)
-            members.add(nid1)
-        new_edge_dict[key] = members
-
-    # replace temporary id by nid2 in edges
-    for key, members in new_edge_dict.items():
-        if id_temp in members:
-            members.remove(id_temp)
-            members.add(nid2)
-        new_edge_dict[key] = members
+    # single-pass swap using a mapping dict
+    swap_map = {nid1: nid2, nid2: nid1}
+    new_edge_dict = {
+        key: {swap_map.get(n, n) for n in members}
+        for key, members in edge_dict.items()
+    }
 
     # update hypergraph with new edges
     HH.remove_edges_from(edge_dict)


### PR DESCRIPTION
  Optimize `node_swap` by replacing the three-loop temp-ID swap with a  single-pass dictionary mapping. Closes #642 

  **Old approach:** used a temporary node ID to swap in three sequential  passes — replace `nid1 → temp`, then `nid2 → nid1`, then `temp → nid2` —  plus a `deepcopy` of the full edge dict.

  **New approach:** builds a `{nid1: nid2, nid2: nid1}` mapping and remaps  each edge's members in a single dict comprehension. Handles the edge case  where both nodes appear in the same edge correctly (the swap is applied
  atomically per member, leaving the set unchanged). Removes the `id_temp` parameter and the `deepcopy` import entirely.

  **Timing** 

Single swap on an `xgi.random_hypergraph` averaged over runs.

  | nodes | edges  | before (ms) | after (ms) | speedup |
  |------:|-------:|------------:|-----------:|--------:|
  |    50 |    324 |        3.13 |       2.08 |   1.51x |
  |   200 |  7 533 |       70.69 |      46.71 |   1.51x |
  |   500 | 24 396 |      248.70 |      160.23 |  1.55x |
  | 1 000 | 93 195 |      958.04 |      643.82 |  1.49x |

The ~1.5x speedup is consistent across sizes. 

**Tests**

Added some tests for uncovered cases.