### PR TITLE
fix: only proxy actual stats through Hypergraph.__getattr__ (#408)

### DIFF
--- a/tests/core/test_dihypergraph.py
+++ b/tests/core/test_dihypergraph.py
@@ -779,3 +779,44 @@ def test_cleanup(dihypergraph1):
     assert edge_in == xgi.dual_dict(node_out)
     assert edge_out == xgi.dual_dict(node_in)
     assert cleanDH["name"] == "test"
+
+
+def test_getattr_only_proxies_stats():
+    """DiHypergraph.__getattr__ must only delegate to actual stats, not arbitrary
+    view methods. See issue #408."""
+    DH = xgi.DiHypergraph([([1, 2], [3, 4]), ([2], [5, 6])])
+
+    # Built-in stats remain accessible
+    assert DH.degree(1) == 1
+    assert DH.in_degree(3) == 1
+    assert DH.out_degree(1) == 1
+    assert DH.size(0) == 4
+
+    # User-defined stats remain accessible
+    @xgi.dinodestat_func
+    def my_stat(net, bunch):
+        return {n: 7 for n in bunch}
+
+    assert all(v == 7 for v in DH.my_stat().values())
+
+    # Non-stat view methods are NOT exposed via DiHypergraph
+    for name in (
+        "filterby",
+        "filterby_attr",
+        "neighbors",
+        "memberships",
+        "dimemberships",
+        "isolates",
+        "members",
+        "dimembers",
+        "head",
+        "tail",
+        "lookup",
+        "duplicates",
+    ):
+        with pytest.raises(AttributeError):
+            getattr(DH, name)
+
+    # Sanity: unknown attribute still raises
+    with pytest.raises(AttributeError):
+        DH.this_does_not_exist

--- a/tests/core/test_hypergraph.py
+++ b/tests/core/test_hypergraph.py
@@ -1043,3 +1043,42 @@ def test_cleanup_empties():
     cleanH = H.cleanup(connected=False, empties=True, relabel=False, in_place=False)
     assert cleanH.num_edges == 3
     assert set(cleanH.edges.empty()) == {2}
+
+
+def test_getattr_only_proxies_stats():
+    """Hypergraph.__getattr__ must only delegate to actual stats, not arbitrary
+    view methods. See issue #408."""
+    H = xgi.Hypergraph([[1, 2, 3], [3, 4, 5]])
+
+    # Built-in stats remain accessible
+    assert H.degree() == {1: 1, 2: 1, 3: 2, 4: 1, 5: 1}
+    assert H.size() == {0: 3, 1: 3}
+    assert H.attrs() == {1: {}, 2: {}, 3: {}, 4: {}, 5: {}}
+
+    # User-defined stats remain accessible
+    @xgi.nodestat_func
+    def my_stat(net, bunch):
+        return {n: 42 for n in bunch}
+
+    assert H.my_stat() == {1: 42, 2: 42, 3: 42, 4: 42, 5: 42}
+
+    # Non-stat view methods are NOT exposed via Hypergraph
+    for name in (
+        "filterby",
+        "filterby_attr",
+        "neighbors",
+        "memberships",
+        "isolates",
+        "singletons",
+        "empty",
+        "maximal",
+        "members",
+        "lookup",
+        "duplicates",
+    ):
+        with pytest.raises(AttributeError):
+            getattr(H, name)
+
+    # Sanity: unknown attribute still raises
+    with pytest.raises(AttributeError):
+        H.this_does_not_exist

--- a/xgi/core/dihypergraph.py
+++ b/xgi/core/dihypergraph.py
@@ -11,6 +11,7 @@ from itertools import count
 from warnings import warn
 
 from ..exception import IDNotFound, XGIError, frozen
+from ..stats import IDStat
 from ..utils import IDDict, update_uid_counter
 from .views import DiEdgeView, DiNodeView
 
@@ -247,12 +248,15 @@ class DiHypergraph:
         self._net_attr[attr] = val
 
     def __getattr__(self, attr):
+        # Only proxy actual stats (DiNodeStat / DiEdgeStat).  Without the
+        # IDStat check, every view method would be exposed via DiHypergraph and
+        # fail with confusing errors when called.  See issue #408.
         stat = getattr(self.nodes, attr, None)
         word = "nodes"
-        if stat is None:
+        if not isinstance(stat, IDStat):
             stat = getattr(self.edges, attr, None)
             word = "edges"
-        if stat is None:
+        if not isinstance(stat, IDStat):
             word = None
             raise AttributeError(
                 f"{attr} is not a method of DiHypergraph or a recognized DiNodeStat or DiEdgeStat"

--- a/xgi/core/hypergraph.py
+++ b/xgi/core/hypergraph.py
@@ -9,6 +9,7 @@ from warnings import warn
 import numpy as np
 
 from ..exception import IDNotFound, XGIError, frozen
+from ..stats import IDStat
 from ..utils import IDDict, update_uid_counter
 from .views import EdgeView, NodeView
 
@@ -244,12 +245,16 @@ class Hypergraph:
         self._net_attr[attr] = val
 
     def __getattr__(self, attr):
+        # Only proxy actual stats (NodeStat / EdgeStat).  Without the IDStat
+        # check, every IDView method (filterby, neighbors, memberships, ...)
+        # would be exposed via Hypergraph and fail with confusing errors when
+        # called.  See issue #408.
         stat = getattr(self.nodes, attr, None)
         word = "nodes"
-        if stat is None:
+        if not isinstance(stat, IDStat):
             stat = getattr(self.edges, attr, None)
             word = "edges"
-        if stat is None:
+        if not isinstance(stat, IDStat):
             word = None
             raise AttributeError(
                 f"{attr} is not a method of Hypergraph or a "


### PR DESCRIPTION
## Summary

Closes #408. `Hypergraph.__getattr__` (and `DiHypergraph.__getattr__`) blindly delegated every attribute lookup to the underlying views and wrapped whatever it found in a function that calls `.asdict()`. That works for actual stats but produces confusing errors when users hit view methods that happen to share a name with no stat:

```python
>>> H.filterby()
TypeError: IDView.filterby() missing 2 required positional arguments: 'stat' and 'val'

>>> H.memberships()
AttributeError: 'dict' object has no attribute 'asdict'

>>> H.neighbors()
TypeError: IDView.neighbors() missing 1 required positional argument: 'idx'
```

## Fix

Tighten the delegation check from `stat is None` to `not isinstance(stat, IDStat)`. Built-in stats (registered via `_stat_property`) and user-defined stats (via `@nodestat_func` etc.) both return `IDStat` instances, so they continue to work. Non-stat view methods (`filterby`, `neighbors`, `memberships`, `isolates`, `singletons`, `empty`, `members`, `dimembers`, `head`, `tail`, ...) now correctly raise `AttributeError` at lookup time with the existing helpful message.

Same one-line change in both `Hypergraph` and `DiHypergraph`.

**Safety check:** grepped `xgi/`, `tests/`, and `tutorials/` for `H.filterby(`, `H.neighbors(`, `H.memberships(`, etc. — zero hits. Nothing in the repo relied on the broken proxies.

## Test plan

- [x] Two new regression tests (`test_getattr_only_proxies_stats` for both `Hypergraph` and `DiHypergraph`) covering: built-in stats still work, user-defined stats still work, every non-stat view method raises `AttributeError`, unknown attributes raise `AttributeError`
- [x] Full test suite passes (420 passed, 6 skipped)