### PR TITLE
refactor: mark read_json/write_json as internal helpers (#697)

### DIFF
--- a/tests/readwrite/test_json.py
+++ b/tests/readwrite/test_json.py
@@ -5,7 +5,7 @@ import pytest
 
 import xgi
 from xgi.exception import XGIError
-from xgi.readwrite.json import read_json, write_json
+from xgi.readwrite.json import _read_json as read_json, _write_json as write_json
 
 json_string1 = """
 {

--- a/tests/readwrite/test_xgi_data.py
+++ b/tests/readwrite/test_xgi_data.py
@@ -7,7 +7,7 @@ import pytest
 
 from xgi import download_xgi_data, load_xgi_data
 from xgi.exception import XGIError
-from xgi.readwrite.json import read_json
+from xgi.readwrite.json import _read_json as read_json
 
 
 @pytest.mark.skipif(

--- a/xgi/convert/hypergraph_dict.py
+++ b/xgi/convert/hypergraph_dict.py
@@ -31,8 +31,8 @@ def to_hypergraph_dict(H):
 
     See Also
     --------
-    ~xgi.readwrite.json.read_json
-    ~xgi.readwrite.json.write_json
+    ~xgi.readwrite.hif.read_hif
+    ~xgi.readwrite.hif.write_hif
     """
     data = {}
     data["type"] = get_network_type(H)

--- a/xgi/readwrite/json.py
+++ b/xgi/readwrite/json.py
@@ -1,19 +1,24 @@
-"""Read from and write to JSON."""
+"""Internal JSON readers/writers used by xgi_data.
+
+These functions are private to xgi.readwrite. Public users should use
+``read_hif`` / ``write_hif`` from :mod:`xgi.readwrite.hif`. They remain
+here only because the xgi-data repository still stores datasets in the
+legacy hypergraph-dict JSON format, and :mod:`xgi.readwrite.xgi_data`
+needs to read and write that format.
+"""
 
 import json
 from collections import defaultdict
 from os.path import dirname, join
-from warnings import warn
 
 from ..convert import from_hypergraph_dict, to_hypergraph_dict
 from ..core import Hypergraph, SimplicialComplex
 
-__all__ = ["write_json", "read_json"]
+__all__ = []
 
 
-def write_json(H, path, collection_name=""):
-    """
-    A function to write a file in a standardized JSON format.
+def _write_json(H, path, collection_name=""):
+    """Write a hypergraph to the legacy xgi-data JSON format.
 
     If the dataset is a collection, makes local copies of all the
     datasets in the collection and a main file pointing to all of
@@ -37,7 +42,6 @@ def write_json(H, path, collection_name=""):
         to strings, e.g., node IDs "2" and 2.
 
     """
-    warn("This function is deprecated in favor of the 'write_hif()' function")
     if collection_name:
         collection_name += "_"
 
@@ -48,7 +52,7 @@ def write_json(H, path, collection_name=""):
             collection_data["datasets"][i] = {
                 "relative-path": f"{collection_name}{i}.json"
             }
-            write_json(H, fname)
+            _write_json(H, fname)
         collection_data["type"] = "collection"
         datastring = json.dumps(collection_data, indent=2)
         with open(
@@ -63,7 +67,7 @@ def write_json(H, path, collection_name=""):
             collection_data["datasets"][name] = {
                 "relative-path": f"{collection_name}{name}.json"
             }
-            write_json(H, fname)
+            _write_json(H, fname)
         collection_data["type"] = "collection"
         datastring = json.dumps(collection_data, indent=2)
         with open(
@@ -78,14 +82,13 @@ def write_json(H, path, collection_name=""):
             output_file.write(datastring)
 
 
-def read_json(path, nodetype=None, edgetype=None):
-    """
-    A function to read a file in a standardized JSON format.
+def _read_json(path, nodetype=None, edgetype=None):
+    """Read a hypergraph from the legacy xgi-data JSON format.
 
     Parameters
     ----------
-    data: dict
-        A dictionary in the hypergraph JSON format
+    path: str
+        Path to a JSON file in the hypergraph-dict format.
     nodetype: type, optional
         type that the node IDs will be cast to
     edgetype: type, optional
@@ -103,7 +106,6 @@ def read_json(path, nodetype=None, edgetype=None):
         If the JSON is not in a format that can be loaded.
 
     """
-    warn("This function is deprecated in favor of the 'read_hif()' function")
     with open(path) as file:
         jsondata = json.loads(file.read())
 
@@ -111,7 +113,7 @@ def read_json(path, nodetype=None, edgetype=None):
         collection = {}
         for name, data in jsondata["datasets"].items():
             relpath = data["relative-path"]
-            H = read_json(
+            H = _read_json(
                 join(dirname(path), relpath), nodetype=nodetype, edgetype=edgetype
             )
             collection[name] = H

--- a/xgi/readwrite/xgi_data.py
+++ b/xgi/readwrite/xgi_data.py
@@ -58,9 +58,9 @@ def load_xgi_data(
     if read:
         cfp = join(path, dataset + ".json")
         if exists(cfp):
-            from ..readwrite import read_json
+            from .json import _read_json
 
-            return read_json(cfp, nodetype=nodetype, edgetype=edgetype)
+            return _read_json(cfp, nodetype=nodetype, edgetype=edgetype)
         else:
             warn(
                 f"No local copy was found at {cfp}. The data is requested "
@@ -108,7 +108,7 @@ def download_xgi_data(dataset, path="", collection_name=""):
         The name of the collection of data (if any). If `dataset` is not
         a collection, this argument is unused.
     """
-    from ..readwrite import write_json
+    from .json import _write_json
 
     index_url = "https://raw.githubusercontent.com/xgi-org/xgi-data/main/index.json"
     index_data = request_json_from_url(index_url)
@@ -125,10 +125,10 @@ def download_xgi_data(dataset, path="", collection_name=""):
         url, nodetype=None, edgetype=None, max_order=None, cache=True
     )
     if isinstance(H, dict):
-        write_json(H, path, collection_name=collection_name)
+        _write_json(H, path, collection_name=collection_name)
     else:
         filename = join(path, key + ".json")
-        write_json(H, filename)
+        _write_json(H, filename)
 
 
 def _request_from_xgi_data(


### PR DESCRIPTION
## Summary

Closes #697 (Option 1 path).

\`read_json\`/\`write_json\` had already been pulled from the top-level public API in #692 but still lived under public names and emitted \`DeprecationWarning\`s. The advice in those warnings ('use \`read_hif\`/\`write_hif\` instead') was misleading for the only remaining caller — \`xgi_data.py\` — because xgi-data still stores datasets in the legacy hypergraph-dict JSON format, not HIF, and the internal caller had nowhere else to go.

This PR completes the cleanup:
- Rename \`read_json\` → \`_read_json\`, \`write_json\` → \`_write_json\` so the private status is obvious.
- Drop the \`DeprecationWarning\` calls.
- \`__all__\` explicitly empty.
- Update the one internal call site in \`xgi/readwrite/xgi_data.py\`.
- Update \`See Also\` references in \`hypergraph_dict.py\` to point at the HIF readers/writers.
- Tests adjusted via import alias so the existing coverage is preserved.

Once xgi-data finishes migrating to HIF (tracked separately by Nich/Dan), these helpers can be deleted entirely.

## Test plan

- [x] Full test suite passes (418 passed, 6 skipped)
- [x] No deprecation warning emitted by xgi-data calls anymore