### PR TITLE
refactor: standardize exception types across public API

### DIFF
--- a/tests/core/test_dihypergraph.py
+++ b/tests/core/test_dihypergraph.py
@@ -163,7 +163,7 @@ def test_add_node_to_edge():
     assert H.nodes["E"] == {}
 
     # test bad direction
-    with pytest.raises(XGIError):
+    with pytest.raises(ValueError):
         H.add_node_to_edge(0, 1, "test")
 
 
@@ -171,7 +171,7 @@ def test_remove_node_from_edge(diedgelist1, diedgelist2):
     H = xgi.DiHypergraph(diedgelist1)
 
     # test bad direction
-    with pytest.raises(XGIError):
+    with pytest.raises(ValueError):
         H.remove_node_from_edge(0, 1, "test")
 
     # test non-existent node
@@ -217,7 +217,7 @@ def test_remove_node_from_edge(diedgelist1, diedgelist2):
 
 def test_add_edge_rejects_set():
     H = xgi.DiHypergraph()
-    with pytest.raises(XGIError):
+    with pytest.raises(TypeError):
         H.add_edge({(1, 2), (3, 4)})
 
 

--- a/tests/core/test_simplicialcomplex.py
+++ b/tests/core/test_simplicialcomplex.py
@@ -350,17 +350,19 @@ def test_add_simplices_from(edgelist5):
 
 
 def test_add_simplices_from_wrong_format():
+    # non-iterable members → ValueError (bad value)
     edges = [0, 1, 2]
-    with pytest.raises(XGIError):
+    with pytest.raises(ValueError):
         xgi.SimplicialComplex().add_simplices_from(edges)
 
+    # string members → TypeError (wrong type)
     edges = [
         ("foo", {"color": "red"}),
         ("bar", {"age": 30}),
         ("baz", {"color": "blue", "age": 40}),
     ]
 
-    with pytest.raises(XGIError):
+    with pytest.raises(TypeError):
         xgi.SimplicialComplex().add_simplices_from(edges)
 
     edges = [
@@ -368,19 +370,19 @@ def test_add_simplices_from_wrong_format():
         ("bar", "two", {"age": 30}),
         ("baz", "three", {"color": "blue", "age": 40}),
     ]
-    with pytest.raises(XGIError):
+    with pytest.raises(TypeError):
         xgi.SimplicialComplex().add_simplices_from(edges)
 
     edges = ["a", "b", "c"]
-    with pytest.raises(XGIError):
+    with pytest.raises(TypeError):
         xgi.SimplicialComplex().add_simplices_from(edges)
 
     edges = ["foo", "bar", "baz"]
-    with pytest.raises(XGIError):
+    with pytest.raises(TypeError):
         xgi.SimplicialComplex().add_simplices_from(edges)
 
     edges = ["foo", [1, 2], [2, 3, 4]]
-    with pytest.raises(XGIError):
+    with pytest.raises(TypeError):
         xgi.SimplicialComplex().add_simplices_from(edges)
 
 

--- a/tests/drawing/test_draw.py
+++ b/tests/drawing/test_draw.py
@@ -677,7 +677,7 @@ def test_draw_bipartite(diedgelist2, edgelist8):
     plt.close("all")
 
     # test type
-    with pytest.raises(XGIError):
+    with pytest.raises(TypeError):
         xgi.draw_bipartite([0, 1, 2])
 
     # test gca

--- a/xgi/algorithms/centrality.py
+++ b/xgi/algorithms/centrality.py
@@ -210,10 +210,10 @@ def line_vector_centrality(H):
             for node in edge:
                 try:
                     c_i[node] += LGcent[edge_label_dict[edge]]
-                except IndexError:
-                    raise Exception(
+                except IndexError as e:
+                    raise ValueError(
                         "Nodes must be written with the Pythonic indexing (0,1,2...)"
-                    )
+                    ) from e
 
         c_i *= 1 / k
 

--- a/xgi/core/dihypergraph.py
+++ b/xgi/core/dihypergraph.py
@@ -557,7 +557,7 @@ class DiHypergraph:
             tail = members[0]
             head = members[1]
         else:
-            raise XGIError("Directed edge must be a list or tuple!")
+            raise TypeError("Directed edge must be a list or tuple!")
 
         if idx is None:
             uid = self._edge_uid
@@ -702,12 +702,12 @@ class DiHypergraph:
                     tail = members[0]
                     head = members[1]
                 else:
-                    raise XGIError("Directed edge must be a list or tuple!")
+                    raise TypeError("Directed edge must be a list or tuple!")
 
                 try:
                     self._edge[idx] = {"in": set(tail), "out": set(head)}
                 except TypeError as e:
-                    raise XGIError("Invalid ebunch format") from e
+                    raise ValueError("Invalid ebunch format") from e
 
                 for n in tail:
                     if n not in self._node:
@@ -773,7 +773,7 @@ class DiHypergraph:
                     head = members[1]
                     self._edge[idx] = {"in": set(tail), "out": set(head)}
                 except TypeError as e:
-                    raise XGIError("Invalid ebunch format") from e
+                    raise ValueError("Invalid ebunch format") from e
 
                 for node in tail:
                     if node not in self._node:
@@ -828,7 +828,7 @@ class DiHypergraph:
             ed = "out"
             nd = "in"
         else:
-            raise XGIError("Invalid direction!")
+            raise ValueError("Invalid direction!")
 
         if edge not in self._edge:
             self._edge[edge] = {"in": set(), "out": set()}
@@ -935,7 +935,7 @@ class DiHypergraph:
             ed = "out"
             nd = "in"
         else:
-            raise XGIError("Invalid direction!")
+            raise ValueError("Invalid direction!")
 
         if edge not in self._edge:
             raise XGIError(f"Edge {edge} not in the hypergraph")

--- a/xgi/core/simplicialcomplex.py
+++ b/xgi/core/simplicialcomplex.py
@@ -309,7 +309,7 @@ class SimplicialComplex(Hypergraph):
         try:
             members = frozenset(members)
         except TypeError:
-            raise XGIError("The simplex cannot be cast to a frozenset.")
+            raise TypeError("The simplex cannot be cast to a frozenset.")
 
         if self.has_simplex(members):
             return
@@ -501,7 +501,7 @@ class SimplicialComplex(Hypergraph):
                 try:
                     _ = frozenset(members)
                 except TypeError as e:
-                    raise XGIError("Invalid ebunch format") from e
+                    raise ValueError("Invalid ebunch format") from e
 
                 self._add_simplex(frozenset(members), idx)
 
@@ -549,7 +549,7 @@ class SimplicialComplex(Hypergraph):
         if (format1 and isinstance(first_edge, str)) or (
             not format1 and isinstance(first_elem, str)
         ):
-            raise XGIError("Members cannot be specified as a string")
+            raise TypeError("Members cannot be specified as a string")
 
         faces = []
         # now we may iterate over the rest
@@ -569,7 +569,7 @@ class SimplicialComplex(Hypergraph):
             try:
                 _ = iter(members)
             except TypeError as e:
-                raise XGIError("Invalid ebunch format") from e
+                raise ValueError("Invalid ebunch format") from e
 
             # check that it does not exist yet (based on members, not ID)
             if not members or self.has_simplex(members):
@@ -611,7 +611,7 @@ class SimplicialComplex(Hypergraph):
             try:
                 self._edge[idx] = frozenset(members)
             except TypeError as e:
-                raise XGIError("Invalid ebunch format") from e
+                raise ValueError("Invalid ebunch format") from e
 
             for n in members:
                 if n not in self._node:

--- a/xgi/drawing/draw.py
+++ b/xgi/drawing/draw.py
@@ -361,7 +361,7 @@ def draw(
             **edge_label_kwargs,
         )
     else:
-        raise XGIError("The input must be a SimplicialComplex or Hypergraph")
+        raise TypeError("The input must be a SimplicialComplex or Hypergraph")
 
     ax, node_collection = draw_nodes(
         H=H,
@@ -1834,7 +1834,7 @@ def draw_bipartite(
         is_directed = True
 
     if not isinstance(H, Hypergraph):
-        raise XGIError("The input must be a Hypergraph")
+        raise TypeError("The input must be a Hypergraph")
 
     settings = {
         "min_node_lw": 0,
@@ -1870,7 +1870,7 @@ def draw_bipartite(
     if not pos:
         pos = bipartite_spring_layout(H)
     elif not (isinstance(pos[0], dict) and isinstance(pos[1], dict)):
-        raise XGIError("Position must be a 2-tuple of dictionaries!")
+        raise TypeError("Position must be a 2-tuple of dictionaries!")
 
     node_pos, edge_pos = pos
 
@@ -2048,7 +2048,7 @@ def draw_undirected_dyads(
     settings.update(kwargs)
 
     if not isinstance(H, Hypergraph):
-        raise XGIError("The input must be a Hypergraph")
+        raise TypeError("The input must be a Hypergraph")
 
     if not pos:
         pos = bipartite_spring_layout(H)
@@ -2249,7 +2249,7 @@ def draw_directed_dyads(
     settings.update(kwargs)
 
     if not isinstance(H, DiHypergraph):
-        raise XGIError("Input must be a DiHypergraph")
+        raise TypeError("Input must be a DiHypergraph")
 
     if not pos:
         from ..convert import to_hypergraph

--- a/xgi/generators/uniform.py
+++ b/xgi/generators/uniform.py
@@ -199,7 +199,7 @@ def uniform_HSBM(n, m, p, sizes, seed=None):
             partition_sizes = [len(partition[i]) for i in block]
             max_index = reduce(operator.mul, partition_sizes, 1)
             if max_index < 0:
-                raise Exception("Index overflow error!")
+                raise OverflowError("Edge index overflowed integer range.")
             index = geometric(p[block], rng=rng) - 1
 
             while index < max_index:
@@ -551,5 +551,5 @@ def _index_to_edge_partition(index, partition_sizes, m):
             int(index // np.prod(partition_sizes[r + 1 :]) % partition_sizes[r])
             for r in range(m)
         ]
-    except KeyError:
-        raise Exception("Invalid parameters")
+    except KeyError as e:
+        raise ValueError("Invalid parameters") from e

--- a/xgi/readwrite/hif.py
+++ b/xgi/readwrite/hif.py
@@ -152,5 +152,5 @@ def read_hif_collection(path, nodetype=None, edgetype=None):
             )
             collection[name] = H
         return collection
-    except KeyError:
-        raise XGIError("Data collection is in the wrong format!")
+    except KeyError as e:
+        raise ValueError("Data collection is in the wrong format!") from e


### PR DESCRIPTION
## Summary

\`xgi/exception.py\` already documents the intended convention:

\`\`\`
TypeError  : wrong runtime type passed
ValueError : type is right but value is invalid
XGIError   : violation of an xgi-specific invariant
IDNotFound : missing node/edge id
\`\`\`

But the codebase didn't follow it consistently — \`XGIError\` was used for type errors and for "Invalid X" value errors, and three bare \`raise Exception(...)\` calls slipped in. PR #732 caught one drift (the kwarg validation in \`draw\`); this PR completes the sweep across the hot paths.

## Changes

### Bare \`raise Exception\` replaced with specific types (3)
- \`xgi/algorithms/centrality.py\` — Pythonic-indexing assertion → \`ValueError\`
- \`xgi/generators/uniform.py\` — index overflow → \`OverflowError\`
- \`xgi/generators/uniform.py\` — invalid parameters → \`ValueError\`

### \`XGIError\` → \`TypeError\` (wrong runtime type)
- \`DiHypergraph.add_edge\` / \`add_edges_from\` when given a non-list/tuple directed edge
- \`SimplicialComplex.add_simplex\` when the simplex cannot be cast to a frozenset or when members are a string
- \`draw\` / \`draw_nodes\` / \`draw_bipartite\` / \`draw_directed_dyads\` when the first positional arg is not a network of the expected type
- \`draw_bipartite\` when \`pos\` is not a 2-tuple of dicts

### \`XGIError\` → \`ValueError\` (right type, invalid value)
- \`DiHypergraph\` "Invalid direction" (in \`add_node_to_edge\` and \`remove_node_from_edge\`)
- \`DiHypergraph\` / \`SimplicialComplex\` "Invalid ebunch format"
- \`readwrite.hif\` "Data collection is in the wrong format"

### Tests
- 5 existing tests updated to expect the new (more specific) exception types in the cases affected
- Total 418 passed, 6 skipped

## Breaking change note

Code that does \`except XGIError:\` to catch what was actually a type or value error will no longer catch it. \`XGIError\` does not inherit from \`TypeError\` or \`ValueError\`. Users should catch the more specific (Python builtin) exceptions, which is the correct Python convention anyway. Worth a changelog entry.