### PR TITLE
Document node label font size in draw

### DIFF
--- a/xgi/drawing/draw.py
+++ b/xgi/drawing/draw.py
@@ -227,6 +227,10 @@ def draw(
         * "min_dyad_lw" (default: 1)
         * "max_dyad_lw" (default: 10)
 
+        When ``node_labels`` is enabled, keyword arguments accepted by
+        :func:`draw_node_labels` can also be passed here. For example,
+        ``font_size_nodes=12`` changes the node label font size.
+
     Returns
     -------
     ax : matplotlib Axes


### PR DESCRIPTION
Fixes #500.

`draw()` forwards keyword arguments through to `draw_nodes()`, which in turn forwards node-label options to `draw_node_labels()` when `node_labels` is enabled. The docs did not make it obvious that this includes `font_size_nodes`, so users could miss how to change node label font sizes from `draw()`.

This adds a short note to the `draw()` docstring showing `font_size_nodes=12` and linking the accepted keywords to `draw_node_labels()`.

Verification:

```console
$ python3 - <<'PY'
from pathlib import Path
s = Path('xgi/drawing/draw.py').read_text()
assert 'font_size_nodes=12' in s
assert ':func:`draw_node_labels`' in s
print('draw docstring documents node label font-size kwargs')
PY
draw docstring documents node label font-size kwargs

$ python3 -m py_compile xgi/drawing/draw.py
```
