### PR TITLE
docs: clarify node label styling in draw

### DIFF
--- a/tests/drawing/test_draw.py
+++ b/tests/drawing/test_draw.py
@@ -61,6 +61,18 @@ def test_draw(edgelist8):
     plt.close("all")
 
 
+def test_draw_forwards_node_label_keywords(edgelist8):
+    H = xgi.Hypergraph(edgelist8)
+
+    fig, ax = plt.subplots()
+    xgi.draw(H, ax=ax, node_labels=True, font_size_nodes=14)
+
+    assert len(ax.texts) == H.num_nodes
+    assert all(text.get_fontsize() == 14 for text in ax.texts)
+
+    plt.close("all")
+
+
 def test_draw_nodes(edgelist8):
 
     H = xgi.Hypergraph(edgelist8)

--- a/xgi/drawing/draw.py
+++ b/xgi/drawing/draw.py
@@ -227,6 +227,10 @@ def draw(
         * "min_dyad_lw" (default: 1)
         * "max_dyad_lw" (default: 10)
 
+        When ``node_labels`` is set, keyword arguments accepted by
+        :func:`draw_node_labels` can also be passed here. For example,
+        use ``font_size_nodes`` to change the node label text size.
+
     Returns
     -------
     ax : matplotlib Axes
@@ -430,7 +434,10 @@ def draw_nodes(
         * "max_node_lw" (default: 5)
 
     kwargs : optional keywords
-        See `draw_node_labels` for a description of optional keywords.
+        When ``node_labels`` is set, these keywords are forwarded to
+        :func:`draw_node_labels`. For example, use ``font_size_nodes`` to change
+        the node label text size. See :func:`draw_node_labels` for all label
+        keyword arguments.
 
     Returns
     -------


### PR DESCRIPTION
## What changed

Clarified the `draw()` and `draw_nodes()` docstrings so users can discover that node label styling options from `draw_node_labels()`, such as `font_size_nodes`, can be passed through keyword arguments when node labels are enabled.

I also added a focused regression test showing `xgi.draw(..., node_labels=True, font_size_nodes=...)` forwards the label keyword and updates the rendered text size.

Fixes #500.

## Validation

- `.venv/bin/python -m pytest tests/drawing/test_draw.py::test_draw_forwards_node_label_keywords -q`
- `.venv/bin/python -m py_compile xgi/drawing/draw.py tests/drawing/test_draw.py`

I also ran `.venv/bin/python -m pytest tests/drawing/test_draw.py -q`; the new test passed, but the full file has one unrelated failure in `test_issue_515` from a NumPy/Matplotlib overflow warning in `draw_multilayer()` under the freshly installed latest dependencies.