### PR TITLE
Make networks copyable and picklable on Python 3.14

### DIFF
--- a/tests/core/test_dihypergraph.py
+++ b/tests/core/test_dihypergraph.py
@@ -830,4 +830,5 @@ def test_uid_counter_survives_copy_and_pickle(diedgelist1):
     for clone in (H.copy(), copy(H), deepcopy(H), pickle.loads(pickle.dumps(H))):
         clone.add_edge([[1], [2]])
         assert expected in clone.edges
-        assert clone._edge_uid is not H._edge_uid
+        # the clone owns its counter: advancing it must not move the original's
+        assert H._edge_uid == expected

--- a/tests/core/test_dihypergraph.py
+++ b/tests/core/test_dihypergraph.py
@@ -820,3 +820,14 @@ def test_getattr_only_proxies_stats():
     # Sanity: unknown attribute still raises
     with pytest.raises(AttributeError):
         DH.this_does_not_exist
+
+
+def test_uid_counter_survives_copy_and_pickle(diedgelist1):
+    """copy/deepcopy/pickle must work and must preserve the next edge uid (see #746)."""
+    H = xgi.DiHypergraph(diedgelist1)
+    expected = H.num_edges
+
+    for clone in (H.copy(), copy(H), deepcopy(H), pickle.loads(pickle.dumps(H))):
+        clone.add_edge([[1], [2]])
+        assert expected in clone.edges
+        assert clone._edge_uid is not H._edge_uid

--- a/tests/core/test_hypergraph.py
+++ b/tests/core/test_hypergraph.py
@@ -1092,18 +1092,9 @@ def test_uid_counter_survives_copy_and_pickle(edgelist1):
     for clone in (H.copy(), copy(H), deepcopy(H), pickle.loads(pickle.dumps(H))):
         clone.add_edge([1, 2])
         assert expected in clone.edges
-        assert clone._edge_uid is not H._edge_uid
+        # the clone owns its counter: advancing it must not move the original's
+        assert H._edge_uid == expected
 
     # the original is untouched by having been copied
     H.add_edge([1, 2])
     assert expected in H.edges
-
-
-def test_uid_counter_value_does_not_advance_the_counter(edgelist1):
-    H = xgi.Hypergraph(edgelist1)
-
-    first = xgi.utils.uid_counter_value(H)
-    second = xgi.utils.uid_counter_value(H)
-
-    assert first == second
-    assert next(H._edge_uid) == first

--- a/tests/core/test_hypergraph.py
+++ b/tests/core/test_hypergraph.py
@@ -1082,3 +1082,28 @@ def test_getattr_only_proxies_stats():
     # Sanity: unknown attribute still raises
     with pytest.raises(AttributeError):
         H.this_does_not_exist
+
+
+def test_uid_counter_survives_copy_and_pickle(edgelist1):
+    """copy/deepcopy/pickle must work and must preserve the next edge uid (see #746)."""
+    H = xgi.Hypergraph(edgelist1)
+    expected = H.num_edges
+
+    for clone in (H.copy(), copy(H), deepcopy(H), pickle.loads(pickle.dumps(H))):
+        clone.add_edge([1, 2])
+        assert expected in clone.edges
+        assert clone._edge_uid is not H._edge_uid
+
+    # the original is untouched by having been copied
+    H.add_edge([1, 2])
+    assert expected in H.edges
+
+
+def test_uid_counter_value_does_not_advance_the_counter(edgelist1):
+    H = xgi.Hypergraph(edgelist1)
+
+    first = xgi.utils.uid_counter_value(H)
+    second = xgi.utils.uid_counter_value(H)
+
+    assert first == second
+    assert next(H._edge_uid) == first

--- a/tests/core/test_simplicialcomplex.py
+++ b/tests/core/test_simplicialcomplex.py
@@ -183,7 +183,7 @@ def test_add_simplices_from_format2():
 
     # check counter
     H.add_simplex([1, 9, 2])
-    assert next(H._edge_uid) == 107
+    assert H._edge_uid == 107
 
     H1 = xgi.SimplicialComplex([{1, 2}, {2, 3, 4}])
     with pytest.warns(
@@ -224,7 +224,7 @@ def test_add_simplices_from_format3():
     assert H.edges[4] == dict()
     # check counter
     H.add_simplex([1, 9, 2])
-    assert next(H._edge_uid) == 8
+    assert H._edge_uid == 8
 
 
 def test_add_simplices_from_format4():
@@ -252,14 +252,14 @@ def test_add_simplices_from_format4():
     assert H.edges[1] == dict()
     # check counter
     H.add_simplex([1, 9, 2])
-    assert next(H._edge_uid) == 5
+    assert H._edge_uid == 5
 
     H1 = xgi.SimplicialComplex([{1, 2}, {2, 3, 4}])
     with pytest.warns(
         UserWarning, match="uid 0 already exists, cannot add simplex {0, 1}."
     ):
         H1.add_simplices_from([({0, 1}, 0, {"color": "red"})])
-    assert next(H1._edge_uid) == 5
+    assert H1._edge_uid == 5
 
 
 def test_add_edges_from_dict():
@@ -285,7 +285,7 @@ def test_add_edges_from_dict():
         UserWarning, match="uid 0 already exists, cannot add simplex {1, 3}"
     ):
         H1.add_simplices_from({0: {1, 3}})
-    assert next(H1._edge_uid) == 5
+    assert H1._edge_uid == 5
 
 
 def test_add_simplices_from(edgelist5):
@@ -614,4 +614,5 @@ def test_uid_counter_survives_copy_and_pickle(edgelist1):
         # a simplex that is not already present as an auto-added subface
         clone.add_simplex([90, 91])
         assert expected in clone.edges
-        assert clone._edge_uid is not SC._edge_uid
+        # the clone owns its counter: advancing it must not move the original's
+        assert SC._edge_uid == expected

--- a/tests/core/test_simplicialcomplex.py
+++ b/tests/core/test_simplicialcomplex.py
@@ -1,3 +1,5 @@
+import pickle
+from copy import copy, deepcopy
 from warnings import warn
 
 import pytest
@@ -601,3 +603,15 @@ def test_issue_445(edgelist1):
     assert 1 not in S
     assert 0 not in S.edges
     assert S._edge == xgi.dual_dict(S._node)
+
+
+def test_uid_counter_survives_copy_and_pickle(edgelist1):
+    """copy/deepcopy/pickle must work and must preserve the next edge uid (see #746)."""
+    SC = xgi.SimplicialComplex(edgelist1)
+    expected = max(SC.edges) + 1
+
+    for clone in (SC.copy(), copy(SC), deepcopy(SC), pickle.loads(pickle.dumps(SC))):
+        # a simplex that is not already present as an auto-added subface
+        clone.add_simplex([90, 91])
+        assert expected in clone.edges
+        assert clone._edge_uid is not SC._edge_uid

--- a/xgi/core/dihypergraph.py
+++ b/xgi/core/dihypergraph.py
@@ -6,13 +6,18 @@
 """
 
 from collections.abc import Hashable, Iterable
-from copy import copy, deepcopy
+from copy import deepcopy
 from itertools import count
 from warnings import warn
 
 from ..exception import IDNotFound, XGIError, frozen
 from ..stats import IDStat
-from ..utils import IDDict, update_uid_counter
+from ..utils import (
+    IDDict,
+    uid_counter_from_value,
+    uid_counter_value,
+    update_uid_counter,
+)
 from .views import DiEdgeView, DiNodeView
 
 __all__ = ["DiHypergraph"]
@@ -109,7 +114,7 @@ class DiHypergraph:
 
         """
         return {
-            "_edge_uid": self._edge_uid,
+            "_edge_uid": uid_counter_value(self),
             "_net_attr": self._net_attr,
             "_node": self._node,
             "_node_attr": self._node_attr,
@@ -130,7 +135,7 @@ class DiHypergraph:
         -----
         This allows the python multiprocessing module to be used.
         """
-        self._edge_uid = state["_edge_uid"]
+        self._edge_uid = uid_counter_from_value(state["_edge_uid"])
         self._net_attr = state["_net_attr"]
         self._node = state["_node"]
         self._node_attr = state["_node_attr"]
@@ -1042,7 +1047,7 @@ class DiHypergraph:
         )
         cp._net_attr = deepcopy(self._net_attr)
 
-        cp._edge_uid = copy(self._edge_uid)
+        cp._edge_uid = count(uid_counter_value(self))
 
         return cp
 

--- a/xgi/core/dihypergraph.py
+++ b/xgi/core/dihypergraph.py
@@ -7,17 +7,11 @@
 
 from collections.abc import Hashable, Iterable
 from copy import deepcopy
-from itertools import count
 from warnings import warn
 
 from ..exception import IDNotFound, XGIError, frozen
 from ..stats import IDStat
-from ..utils import (
-    IDDict,
-    uid_counter_from_value,
-    uid_counter_value,
-    update_uid_counter,
-)
+from ..utils import IDDict, update_uid_counter
 from .views import DiEdgeView, DiNodeView
 
 __all__ = ["DiHypergraph"]
@@ -114,7 +108,7 @@ class DiHypergraph:
 
         """
         return {
-            "_edge_uid": uid_counter_value(self),
+            "_edge_uid": self._edge_uid,
             "_net_attr": self._net_attr,
             "_node": self._node,
             "_node_attr": self._node_attr,
@@ -135,7 +129,7 @@ class DiHypergraph:
         -----
         This allows the python multiprocessing module to be used.
         """
-        self._edge_uid = uid_counter_from_value(state["_edge_uid"])
+        self._edge_uid = state["_edge_uid"]
         self._net_attr = state["_net_attr"]
         self._node = state["_node"]
         self._node_attr = state["_node_attr"]
@@ -145,7 +139,7 @@ class DiHypergraph:
         self._edgeview = DiEdgeView(self)
 
     def __init__(self, incoming_data=None, **attr):
-        self._edge_uid = count()
+        self._edge_uid = 0
         self._net_attr = self._net_attr_dict_factory()
 
         self._node = self._node_dict_factory()
@@ -565,7 +559,11 @@ class DiHypergraph:
         else:
             raise XGIError("Directed edge must be a list or tuple!")
 
-        uid = next(self._edge_uid) if idx is None else idx
+        if idx is None:
+            uid = self._edge_uid
+            self._edge_uid += 1
+        else:
+            uid = idx
 
         if idx in self._edge.keys():  # check that uid is not present yet
             warn(f"uid {idx} already exists, cannot add edge {members}")
@@ -757,11 +755,13 @@ class DiHypergraph:
         e = first_edge
         while True:
             if format1:
-                members, idx, eattr = e, next(self._edge_uid), {}
+                members, idx, eattr = e, self._edge_uid, {}
+                self._edge_uid += 1
             elif format2:
                 members, idx, eattr = e[0], e[1], {}
             elif format3:
-                members, idx, eattr = e[0], next(self._edge_uid), e[1]
+                members, idx, eattr = e[0], self._edge_uid, e[1]
+                self._edge_uid += 1
             elif format4:
                 members, idx, eattr = e[0], e[1], e[2]
 
@@ -1047,7 +1047,7 @@ class DiHypergraph:
         )
         cp._net_attr = deepcopy(self._net_attr)
 
-        cp._edge_uid = count(uid_counter_value(self))
+        cp._edge_uid = self._edge_uid
 
         return cp
 

--- a/xgi/core/hypergraph.py
+++ b/xgi/core/hypergraph.py
@@ -3,19 +3,13 @@
 from collections import defaultdict
 from collections.abc import Hashable, Iterable
 from copy import deepcopy
-from itertools import count
 from warnings import warn
 
 import numpy as np
 
 from ..exception import IDNotFound, XGIError, frozen
 from ..stats import IDStat
-from ..utils import (
-    IDDict,
-    uid_counter_from_value,
-    uid_counter_value,
-    update_uid_counter,
-)
+from ..utils import IDDict, update_uid_counter
 from .views import EdgeView, NodeView
 
 __all__ = ["Hypergraph"]
@@ -109,7 +103,7 @@ class Hypergraph:
 
         """
         return {
-            "_edge_uid": uid_counter_value(self),
+            "_edge_uid": self._edge_uid,
             "_net_attr": self._net_attr,
             "_node": self._node,
             "_node_attr": self._node_attr,
@@ -130,7 +124,7 @@ class Hypergraph:
         -----
         This allows the python multiprocessing module to be used.
         """
-        self._edge_uid = uid_counter_from_value(state["_edge_uid"])
+        self._edge_uid = state["_edge_uid"]
         self._net_attr = state["_net_attr"]
         self._node = state["_node"]
         self._node_attr = state["_node_attr"]
@@ -140,7 +134,7 @@ class Hypergraph:
         self._edgeview = EdgeView(self)
 
     def __init__(self, incoming_data=None, **attr):
-        self._edge_uid = count()
+        self._edge_uid = 0
         self._net_attr = self._net_attr_dict_factory()
         self._node = self._node_dict_factory()
         self._node_attr = self._node_attr_dict_factory()
@@ -626,7 +620,11 @@ class Hypergraph:
             warn(f"uid {idx} already exists, cannot add edge {members}")
             return
 
-        uid = next(self._edge_uid) if idx is None else idx
+        if idx is None:
+            uid = self._edge_uid
+            self._edge_uid += 1
+        else:
+            uid = idx
 
         self._edge[uid] = set()
         for node in members:
@@ -796,11 +794,13 @@ class Hypergraph:
         e = first_edge
         while True:
             if format1:
-                members, idx, eattr = e, next(self._edge_uid), {}
+                members, idx, eattr = e, self._edge_uid, {}
+                self._edge_uid += 1
             elif format2:
                 members, idx, eattr = e[0], e[1], {}
             elif format3:
-                members, idx, eattr = e[0], next(self._edge_uid), e[1]
+                members, idx, eattr = e[0], self._edge_uid, e[1]
+                self._edge_uid += 1
             elif format4:
                 members, idx, eattr = e[0], e[1], e[2]
 
@@ -1393,7 +1393,8 @@ class Hypergraph:
                 elif rename == "tuple":
                     new_id = tuple(sorted(dup_ids))
                 elif rename == "new":
-                    new_id = next(self._edge_uid)
+                    new_id = self._edge_uid
+                    self._edge_uid += 1
                 else:
                     raise XGIError("Invalid ID renaming scheme!")
 
@@ -1452,7 +1453,7 @@ class Hypergraph:
         )
         cp._net_attr = deepcopy(self._net_attr)
 
-        cp._edge_uid = count(uid_counter_value(self))
+        cp._edge_uid = self._edge_uid
 
         return cp
 

--- a/xgi/core/hypergraph.py
+++ b/xgi/core/hypergraph.py
@@ -2,7 +2,7 @@
 
 from collections import defaultdict
 from collections.abc import Hashable, Iterable
-from copy import copy, deepcopy
+from copy import deepcopy
 from itertools import count
 from warnings import warn
 
@@ -10,7 +10,12 @@ import numpy as np
 
 from ..exception import IDNotFound, XGIError, frozen
 from ..stats import IDStat
-from ..utils import IDDict, update_uid_counter
+from ..utils import (
+    IDDict,
+    uid_counter_from_value,
+    uid_counter_value,
+    update_uid_counter,
+)
 from .views import EdgeView, NodeView
 
 __all__ = ["Hypergraph"]
@@ -104,7 +109,7 @@ class Hypergraph:
 
         """
         return {
-            "_edge_uid": self._edge_uid,
+            "_edge_uid": uid_counter_value(self),
             "_net_attr": self._net_attr,
             "_node": self._node,
             "_node_attr": self._node_attr,
@@ -125,7 +130,7 @@ class Hypergraph:
         -----
         This allows the python multiprocessing module to be used.
         """
-        self._edge_uid = state["_edge_uid"]
+        self._edge_uid = uid_counter_from_value(state["_edge_uid"])
         self._net_attr = state["_net_attr"]
         self._node = state["_node"]
         self._node_attr = state["_node_attr"]
@@ -1447,7 +1452,7 @@ class Hypergraph:
         )
         cp._net_attr = deepcopy(self._net_attr)
 
-        cp._edge_uid = copy(self._edge_uid)
+        cp._edge_uid = count(uid_counter_value(self))
 
         return cp
 

--- a/xgi/core/simplicialcomplex.py
+++ b/xgi/core/simplicialcomplex.py
@@ -9,11 +9,11 @@ Multi-simplices are not allowed.
 
 from collections.abc import Hashable, Iterable
 from copy import deepcopy
-from itertools import combinations, count
+from itertools import combinations
 from warnings import warn
 
 from ..exception import XGIError, frozen
-from ..utils.utilities import powerset, uid_counter_value, update_uid_counter
+from ..utils.utilities import powerset, update_uid_counter
 from .hypergraph import Hypergraph
 from .views import EdgeView, NodeView
 
@@ -92,7 +92,7 @@ class SimplicialComplex(Hypergraph):
     """
 
     def __init__(self, incoming_data=None, **attr):
-        self._edge_uid = count()
+        self._edge_uid = 0
         self._net_attr = self._net_attr_dict_factory()
         self._node = self._node_dict_factory()
         self._node_attr = self._node_attr_dict_factory()
@@ -241,7 +241,8 @@ class SimplicialComplex(Hypergraph):
         """Helper function to add a face to a simplicial complex, without any
         check, and without attributes. Automatically updates self._edge_uid"""
 
-        idx = next(self._edge_uid)
+        idx = self._edge_uid
+        self._edge_uid += 1
         self._edge[idx] = frozenset(members)
 
         for n in members:
@@ -317,7 +318,9 @@ class SimplicialComplex(Hypergraph):
             warn(f"uid {idx} already exists, cannot add simplex {members}")
             return
 
-        idx = next(self._edge_uid) if idx is None else idx
+        if idx is None:
+            idx = self._edge_uid
+            self._edge_uid += 1
 
         self._add_simplex(members, idx, **attr)
 
@@ -580,7 +583,8 @@ class SimplicialComplex(Hypergraph):
             # needs to go after the check for existence, otherwise
             # we're skipping ID numbers when edges already exist
             if format1 or format3:
-                idx = next(self._edge_uid)
+                idx = self._edge_uid
+                self._edge_uid += 1
 
             if max_order is not None:
                 if len(members) > max_order + 1:
@@ -830,7 +834,7 @@ class SimplicialComplex(Hypergraph):
         )
         cp._net_attr = deepcopy(self._net_attr)
 
-        cp._edge_uid = count(uid_counter_value(self))
+        cp._edge_uid = self._edge_uid
 
         return cp
 

--- a/xgi/core/simplicialcomplex.py
+++ b/xgi/core/simplicialcomplex.py
@@ -8,12 +8,12 @@ Multi-simplices are not allowed.
 """
 
 from collections.abc import Hashable, Iterable
-from copy import copy, deepcopy
+from copy import deepcopy
 from itertools import combinations, count
 from warnings import warn
 
 from ..exception import XGIError, frozen
-from ..utils.utilities import powerset, update_uid_counter
+from ..utils.utilities import powerset, uid_counter_value, update_uid_counter
 from .hypergraph import Hypergraph
 from .views import EdgeView, NodeView
 
@@ -830,7 +830,7 @@ class SimplicialComplex(Hypergraph):
         )
         cp._net_attr = deepcopy(self._net_attr)
 
-        cp._edge_uid = copy(self._edge_uid)
+        cp._edge_uid = count(uid_counter_value(self))
 
         return cp
 

--- a/xgi/utils/utilities.py
+++ b/xgi/utils/utilities.py
@@ -3,7 +3,7 @@
 from collections import defaultdict
 from copy import deepcopy
 from functools import cache
-from itertools import chain, combinations, count
+from itertools import chain, combinations
 from math import ceil, log
 
 import numpy as np
@@ -15,8 +15,6 @@ __all__ = [
     "dual_dict",
     "powerset",
     "update_uid_counter",
-    "uid_counter_value",
-    "uid_counter_from_value",
     "find_triangles",
     "request_json_from_url",
     "request_json_from_url_cached",
@@ -158,7 +156,7 @@ def update_uid_counter(H, idx):
     Helper function to make sure the uid counter is set correctly after
     adding an edge with a user-provided ID.
 
-    If we don't set the start of self._edge_uid correctly, it will start at 0,
+    If we don't set self._edge_uid correctly, it will start at 0,
     which will overwrite any existing edges when calling add_edge().  First, we
     use the somewhat convoluted float(e).is_integer() instead of using
     isinstance(e, int) because there exist integer-like numeric types (such as
@@ -172,76 +170,16 @@ def update_uid_counter(H, idx):
         User-provided ID.
 
     """
-    uid = next(H._edge_uid)
     if (
         not isinstance(idx, str)
         and not isinstance(idx, tuple)
         and float(idx).is_integer()
-        and uid <= idx
+        and H._edge_uid <= idx
     ):
         # tuple comes from merging edges and doesn't have as as_integer() method.
-        start = int(idx) + 1
-        # we set the start at one plus the maximum edge ID that is an integer,
-        # because count() only yields integer IDs.
-    else:
-        start = uid
-    H._edge_uid = count(start=start)
-
-
-def uid_counter_value(H):
-    """Return the next edge uid of ``H`` without advancing its counter.
-
-    ``itertools.count`` objects cannot be copied or pickled on Python 3.14 and
-    later, so a network's uid counter has to be stored as a plain integer and
-    rebuilt with :func:`uid_counter_from_value` when it is restored.
-
-    A counter cannot be read without consuming a value, so this takes one and
-    immediately replaces the counter with an equivalent one starting there.
-    ``H`` is left yielding exactly the same sequence it would have yielded.
-
-    Parameters
-    ----------
-    H : xgi.Hypergraph, xgi.DiHypergraph or xgi.SimplicialComplex
-        Network whose uid counter to read.
-
-    Returns
-    -------
-    int
-        The value ``next(H._edge_uid)`` would return.
-
-    See Also
-    --------
-    uid_counter_from_value
-
-    """
-    value = next(H._edge_uid)
-    H._edge_uid = count(value)
-    return value
-
-
-def uid_counter_from_value(value):
-    """Rebuild an edge uid counter from a stored value.
-
-    Parameters
-    ----------
-    value : int or itertools.count
-        A value produced by :func:`uid_counter_value`. A counter is accepted
-        and returned unchanged so that pickles written before uid counters
-        were stored as integers can still be read.
-
-    Returns
-    -------
-    itertools.count
-        A counter starting at ``value``.
-
-    See Also
-    --------
-    uid_counter_value
-
-    """
-    if isinstance(value, count):
-        return value
-    return count(value)
+        # We set the counter to one plus the maximum edge ID that is an integer,
+        # because only integer IDs are ever issued automatically.
+        H._edge_uid = int(idx) + 1
 
 
 def find_triangles(G):

--- a/xgi/utils/utilities.py
+++ b/xgi/utils/utilities.py
@@ -15,6 +15,8 @@ __all__ = [
     "dual_dict",
     "powerset",
     "update_uid_counter",
+    "uid_counter_value",
+    "uid_counter_from_value",
     "find_triangles",
     "request_json_from_url",
     "request_json_from_url_cached",
@@ -184,6 +186,62 @@ def update_uid_counter(H, idx):
     else:
         start = uid
     H._edge_uid = count(start=start)
+
+
+def uid_counter_value(H):
+    """Return the next edge uid of ``H`` without advancing its counter.
+
+    ``itertools.count`` objects cannot be copied or pickled on Python 3.14 and
+    later, so a network's uid counter has to be stored as a plain integer and
+    rebuilt with :func:`uid_counter_from_value` when it is restored.
+
+    A counter cannot be read without consuming a value, so this takes one and
+    immediately replaces the counter with an equivalent one starting there.
+    ``H`` is left yielding exactly the same sequence it would have yielded.
+
+    Parameters
+    ----------
+    H : xgi.Hypergraph, xgi.DiHypergraph or xgi.SimplicialComplex
+        Network whose uid counter to read.
+
+    Returns
+    -------
+    int
+        The value ``next(H._edge_uid)`` would return.
+
+    See Also
+    --------
+    uid_counter_from_value
+
+    """
+    value = next(H._edge_uid)
+    H._edge_uid = count(value)
+    return value
+
+
+def uid_counter_from_value(value):
+    """Rebuild an edge uid counter from a stored value.
+
+    Parameters
+    ----------
+    value : int or itertools.count
+        A value produced by :func:`uid_counter_value`. A counter is accepted
+        and returned unchanged so that pickles written before uid counters
+        were stored as integers can still be read.
+
+    Returns
+    -------
+    itertools.count
+        A counter starting at ``value``.
+
+    See Also
+    --------
+    uid_counter_value
+
+    """
+    if isinstance(value, count):
+        return value
+    return count(value)
 
 
 def find_triangles(G):


### PR DESCRIPTION
Closes #746.

Confirming your diagnosis — and the blast radius is wider than the report. On CPython 3.14 this hits **all three network classes**, and all three of `copy()`, `deepcopy()` and `pickle`, not just `Hypergraph.copy()`:

| | `copy()` | `deepcopy()` | `pickle` |
|---|---|---|---|
| `Hypergraph` | ✗ | ✗ | ✗ |
| `DiHypergraph` | ✗ | ✗ | ✗ |
| `SimplicialComplex` | ✗ | ✗ | ✗ |

all with `TypeError: cannot pickle 'itertools.count' object`. Because `cleanup()`, `merge_duplicate_edges()` and `random_edge_shuffle()` all go through `copy()`, they fail too. **`pytest tests/core/` on `dev` was 17 failed / 125 passed under 3.14**; with this change it is 145 passed.

### Approach

*(Revised after review — see the discussion below. The first version kept `itertools.count` and worked around its non-peekability; @leotrs rightly pushed back, and @nwlandry agreed.)*

`_edge_uid` is now a plain `int`. That removes the problem rather than handling it:

- no helpers — the previous `uid_counter_value` / `uid_counter_from_value` are gone
- `__getstate__`, `__setstate__` and `copy()` are plain assignments
- `next(self._edge_uid)` became `uid = self._edge_uid; self._edge_uid += 1` at all seven call sites
- `update_uid_counter` sets the counter directly
- **`itertools.count` is no longer imported anywhere in the package**, which is the check that it is genuinely gone rather than relocated

Net effect on this PR: **58 insertions against 122 deletions.**

One deliberate deviation from the suggested `H._edge_uid = max(H._edge_uid, idx + 1)`: `idx` is not always a number. `add_edge` accepts string ids and tuples arrive from merged edges, so the `str` / `tuple` / `float(idx).is_integer()` guards are load-bearing and stay — only the body collapsed to a single assignment. `tests/core/test_simplicialcomplex.py` covers both (`["a", "b", 100, 101, 102, 103]`).

### Tests

A regression test per class asserts that `copy()`, `copy.copy()`, `deepcopy()` and a pickle round-trip all succeed, and that the clone's **next edge uid is preserved** — a clone must not reissue an existing id.

Two consequences of moving to an int, both worth flagging:

- five existing tests in `test_simplicialcomplex.py` asserted on the counter via `next(H._edge_uid)` and are now `H._edge_uid == N`. That the tests reached into the counter at all is arguably an argument for this design.
- my own `clone._edge_uid is not H._edge_uid` assertions were meaningless once the value is a small interned int, so they now assert the original's counter is unmoved after the clone advances its own.

Full suite: **430 passed / 6 skipped**. `tests/drawing/test_draw.py::test_issue_515` failed on one earlier run with a numpy overflow and passed on others, both with and without this change — it looks flaky rather than related. `isort` and `black` report no changes on the files I touched.